### PR TITLE
Make HtmlToMarkdown thread-safe when only working builtin tag handlers

### DIFF
--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -45,6 +45,10 @@ pub(crate) struct HandlerRule {
     pub(crate) handler: Box<dyn ElementHandler>,
 }
 
+unsafe impl Send for HandlerRule {}
+
+unsafe impl Sync for HandlerRule {}
+
 impl<F> ElementHandler for F
 where
     F: Fn(Element) -> Option<String>,


### PR DESCRIPTION
- Implement `Send` and `Sync` for [HandlerRule ](https://github.com/letmutex/htmd/blob/cb51d703e84487eab984242f1728d5ae1f49efd0/src/element_handler/mod.rs#L43)
- Use a `thread local` in the [AnchorElementHandler](https://github.com/letmutex/htmd/blob/main/src/element_handler/anchor.rs)

This does NOT provide any thread safety for external tag handlers.
