### PR TITLE
Handle spaces in the URL

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -82,6 +82,7 @@ impl AnchorElementHandler {
     }
 
     fn build_inlined_anchor(&self, content: String, link: String, title: Option<String>) -> String {
+        let has_spaces_in_link = link.contains(' ');
         let (content, leading_whitespace) = content.strip_leading_whitespace();
         let (content, trailing_whitespace) = content.strip_trailing_whitespace();
         concat_strings!(
@@ -89,10 +90,12 @@ impl AnchorElementHandler {
             "[",
             content,
             "](",
+            if has_spaces_in_link { "<" } else { "" },
             link,
             title
                 .as_ref()
                 .map_or(String::new(), |t| concat_strings!(" \"", t, "\"")),
+            if has_spaces_in_link { ">" } else { "" },
             ")",
             trailing_whitespace.unwrap_or("")
         )

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -39,14 +39,18 @@ pub(super) fn img_handler(element: Element) -> Option<String> {
 
     let link = link.map(|text| text.replace("(", "\\(").replace(")", "\\)"));
 
+    let has_spaces_in_link = link.as_ref().is_some_and(|link| link.contains(' '));
+
     let md = concat_strings!(
         "![",
         alt.as_ref().unwrap_or(&String::new()),
         "](",
+        if has_spaces_in_link { "<" } else { "" },
         link.as_ref().unwrap_or(&String::new()),
         title
             .as_ref()
             .map_or(String::new(), |t| concat_strings!(" \"", t, "\"")),
+        if has_spaces_in_link { ">" } else { "" },
         ")"
     );
     Some(md)

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -19,6 +19,15 @@ fn links() {
 }
 
 #[test]
+fn links_with_spaces() {
+    let html = r#"
+        <a href="https://example.com/Some Page.html">Example</a>
+        "#;
+    let md = HtmlToMarkdown::new().convert(html).unwrap();
+    assert_eq!("[Example](<https://example.com/Some Page.html>)", &md)
+}
+
+#[test]
 fn images() {
     let html = r#"
         <img src="https://example.com" />
@@ -29,6 +38,18 @@ fn images() {
     assert_eq!(
         "![](https://example.com)![Image 1](https://example.com)\
             ![Image 2](https://example.com \"Hello\")",
+        &md
+    )
+}
+
+#[test]
+fn images_with_spaces_in_url() {
+    let html = r#"
+        <img src="https://example.com/Some Image.jpg" />
+        "#;
+    let md = HtmlToMarkdown::new().convert(html).unwrap();
+    assert_eq!(
+        "![](<https://example.com/Some Image.jpg>)",
         &md
     )
 }


### PR DESCRIPTION
Currently, htmd doesn't handle links with spaces in them, according to [CommonMark Spec](https://spec.commonmark.org/0.31.2/#links), they should be surrounded by `<` and `>`.

```markdown
[Link](<https://example.com/Some Page.html>)

![Image](<https://example.com/Some Image.jpg>)
```

Some tools (Such as VS Code) cannot render these links without `<...>`