### PR TITLE
Fix: correctly indent ordered lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ html-escape = "0.2.13"
 [dev-dependencies]
 scraper = "0.23.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+pretty_assertions = "1.4.1"
 
 [[bench]]
 name = "convert_bench"

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 pub(super) fn list_item_handler(element: Element) -> Option<String> {
     let content = element.content.trim_start_ascii_whitespace().to_string();
-    let content = indent_text_except_first_line(&content, 4, true);
 
     let ul_li = || {
         let marker = if element.options.bullet_list_marker == BulletListMarker::Asterisk {
@@ -18,18 +17,24 @@ pub(super) fn list_item_handler(element: Element) -> Option<String> {
             "-"
         };
         let spacing = " ".repeat(element.options.ul_bullet_spacing.into());
+        let content = indent_text_except_first_line(&content, marker.len() + spacing.len(), true);
         Some(concat_strings!("\n", marker, spacing, content, "\n"))
     };
 
-    let ol_li = |index: usize| {
-        let spacing = " ".repeat(element.options.ol_number_spacing.into());
+    // Add 1 before computing log10, then take the ceiling: it avoids log10(0) = Nan, and changes log10(10) = 1 into 2,
+    // log10(100) into 3, etc.
+    let digits = |num: usize| ((num + 1) as f32).log10().ceil() as usize;
+
+    let ol_li = |index: usize, highest_list_item: usize| {
+        let index_str = index.to_string();
+        let spacing = " ".repeat(
+            element.options.ol_number_spacing as usize + digits(highest_list_item)
+                - index_str.len(),
+        );
+        let content =
+            indent_text_except_first_line(&content, index_str.len() + 1 + spacing.len(), true);
         Some(concat_strings!(
-            "\n",
-            index.to_string(),
-            ".",
-            spacing,
-            content,
-            "\n"
+            "\n", index_str, ".", spacing, content, "\n"
         ))
     };
 
@@ -59,12 +64,16 @@ pub(super) fn list_item_handler(element: Element) -> Option<String> {
         }
 
         let mut index = 0;
+        let mut total_list_items = 0;
         for child in parent_node.children.borrow().iter() {
+            // Because `index` is assigned before `total_list_items` is incremented,
+            // it is zero-based: the first list item is `index == 0`, the second
+            // is `index == 1`, etc.
             if Rc::ptr_eq(child, element.node) {
-                break;
+                index = total_list_items;
             }
             if get_node_tag_name(child).is_some_and(|tag| tag == "li") {
-                index += 1;
+                total_list_items += 1;
             }
         }
 
@@ -75,7 +84,9 @@ pub(super) fn list_item_handler(element: Element) -> Option<String> {
             .map(|attr| attr.value.to_string().parse::<usize>().unwrap_or(1))
             .unwrap_or(1);
 
-        ol_li(start + index)
+        // The highest list index is `start + total_list_items - 1`, since `start` is one-based, not zero-based.
+        // For example, given `start = 5` and `total_list_items = 2` (a list of 5, 6), the highest index is 6.
+        ol_li(start + index, start + total_list_items - 1)
     } else {
         ul_li()
     }

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -157,7 +157,7 @@ pub(crate) fn indent_text_except_first_line(
     let indent_text = " ".repeat(indent);
     for (idx, line) in text.lines().enumerate() {
         let line = if trim_line_end { line.trim_end() } else { line };
-        if idx == 0 {
+        if idx == 0 || line.is_empty() {
             result_lines.push(line.to_string());
         } else {
             result_lines.push(concat_strings!(indent_text, line));

--- a/tests/html/turndown_test_index.html
+++ b/tests/html/turndown_test_index.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- Very important: **do not** trim trailing whitespace when editing this file. Several
+     tests rely on this whitespace to work properly. -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -353,6 +355,17 @@ def a_fenced_code block; end
 ```</pre>
 </div>
 
+<div class="case" data-name="fenced pre/code/br block with language" data-options='{"codeBlockStyle": "fenced"}'>
+  <div class="input">
+    <pre><code class="language-ruby">def a_fenced_code block;
+end;</code></pre>
+  </div>
+  <pre class="expected">```ruby
+def a_fenced_code block;
+end;
+```</pre>
+</div>
+
 <div class="case" data-name="empty pre does not throw error">
   <div class="input">
     <pre></pre>
@@ -384,6 +397,28 @@ def a_fenced_code block; end
   <pre class="expected">42.  Ordered list item 42
 43.  Ordered list item 43
 44.  Ordered list item 44</pre>
+</div>
+
+<div class="case" data-name="ol with increasing start">
+  <div class="input">
+    <ol start="9">
+      <li>Ordered list item 9</li>
+      <li>Ordered list item 10</li>
+    </ol>
+  </div>
+  <pre class="expected">9.   Ordered list item 9
+10.  Ordered list item 10</pre>
+</div>
+
+<div class="case" data-name="ol with high start">
+  <div class="input">
+    <ol start="99">
+      <li>Ordered list item 99</li>
+      <li>Ordered list item 100</li>
+    </ol>
+  </div>
+  <pre class="expected">99.   Ordered list item 99
+100.  Ordered list item 100</pre>
 </div>
 
 <div class="case" data-name="list spacing">
@@ -448,7 +483,7 @@ Another paragraph.
     </ul>
   </div>
   <pre class="expected">*   List item with paragraph
-    
+
 *   List item without paragraph</pre>
 </div>
 
@@ -465,10 +500,32 @@ Another paragraph.
     </ol>
   </div>
   <pre class="expected">1.  This is a paragraph in a list item.
-    
+
     This is a paragraph in the same list item as above.
-    
+
 2.  A paragraph in a second list item.</pre>
+</div>
+
+<div class="case" data-name="ol with start and paragraphs">
+  <div class="input">
+    <ol start="9">
+      <li>
+        <p>This is a paragraph in a list item.</p>
+        <p>This is a paragraph in the same list item as above.</p>
+      </li>
+      <li>
+        <p>A paragraph in a second list item.</p>
+        <p>This is a paragraph in the same list item as above.</p>
+      </li>
+    </ol>
+  </div>
+  <pre class="expected">9.   This is a paragraph in a list item.
+
+     This is a paragraph in the same list item as above.
+
+10.  A paragraph in a second list item.
+
+     This is a paragraph in the same list item as above.</pre>
 </div>
 
 <div class="case" data-name="nested uls">
@@ -508,7 +565,7 @@ Another paragraph.
       <li>This is a list item at root level</li>
       <li>This is another item at root level</li>
       <li>
-        <ol>
+        <ol start="9">
           <li>This is a nested list item</li>
           <li>This is another nested list item</li>
           <li>
@@ -525,11 +582,11 @@ Another paragraph.
   </div>
   <pre class="expected">*   This is a list item at root level
 *   This is another item at root level
-*   1.  This is a nested list item
-    2.  This is another nested list item
-    3.  *   This is a deeply nested list item
-        *   This is another deeply nested list item
-        *   This is a third deeply nested list item
+*   9.   This is a nested list item
+    10.  This is another nested list item
+    11.  *   This is a deeply nested list item
+         *   This is another deeply nested list item
+         *   This is a third deeply nested list item
 *   This is a third item at root level</pre>
 </div>
 
@@ -545,7 +602,7 @@ Another paragraph.
     </ul>
   </div>
   <pre class="expected">*   A list item with a blockquote:
-    
+
     > This is a blockquote inside a list item.</pre>
 </div>
 
@@ -691,6 +748,13 @@ Another div</pre>
 <div class="case" data-name="whitespace in inline elements">
   <div class="input">Text with no space after the period.<em> Text in em with leading/trailing spaces </em><strong>text in strong with trailing space </strong></div>
   <pre class="expected">Text with no space after the period. _Text in em with leading/trailing spaces_ **text in strong with trailing space**</pre>
+</div>
+
+<!-- Two trailing newlines are for the line break -->
+<div class="case" data-name="newline at the end of a strong element">
+    <div class="input"><strong>Text with a trailing break<br></strong>before continuation</div>
+    <pre class="expected">**Text with a trailing break**  
+before continuation</pre>
 </div>
 
 <div class="case" data-name="whitespace in nested inline elements">

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -5,6 +5,7 @@ use htmd::{
     },
     HtmlToMarkdown,
 };
+use pretty_assertions::assert_eq;
 use scraper::{Html, Selector};
 
 struct TestCase {


### PR DESCRIPTION
This fix mirrors the [same issue in Turndown](https://github.com/mixmark-io/turndown/issues/410): lists like this don't translate correctly.

9. Items
10. Items with an extra digit

It also uses `pretty_assertions` for debug (which helps me see errors more easily), and avoids lines in list items with spaces but no contents.