### PR TITLE
Update rust editing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "htmd"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 authors = ["letmutex"]
 description = "A turndown.js inspired HTML to Markdown converter."
 license = "Apache-2.0"

--- a/benches/convert_bench.rs
+++ b/benches/convert_bench.rs
@@ -2,7 +2,7 @@ extern crate htmd;
 
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use htmd::convert;
 
 fn benchmark(c: &mut Criterion) {

--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -1,4 +1,4 @@
-use htmd::{options::Options, Element, HtmlToMarkdown};
+use htmd::{Element, HtmlToMarkdown, options::Options};
 
 fn main() {
     let converter = HtmlToMarkdown::new();

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -7,8 +7,8 @@ use super::{
     node_util::get_node_tag_name,
     options::Options,
     text_util::{
-        compress_whitespace, index_of_markdown_ordered_item_dot, is_markdown_atx_heading,
-        TrimAsciiWhitespace,
+        TrimAsciiWhitespace, compress_whitespace, index_of_markdown_ordered_item_dot,
+        is_markdown_atx_heading,
     },
 };
 
@@ -126,10 +126,10 @@ fn visit_element(
     );
     // Remove the temporary text clips of children
     buffer.truncate(prev_buffer_len);
-    if let Some(text) = md {
-        if !text.is_empty() || !is_head {
-            buffer.push(text);
-        }
+    if let Some(text) = md
+        && (!text.is_empty() || !is_head)
+    {
+        buffer.push(text);
     }
 }
 

--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -5,7 +5,7 @@ use markup5ever_rcdom::Node;
 
 use crate::{
     options::{LinkReferenceStyle, LinkStyle, Options},
-    text_util::{concat_strings, JoinOnStringIterator, StripWhitespace, TrimAsciiWhitespace},
+    text_util::{JoinOnStringIterator, StripWhitespace, TrimAsciiWhitespace, concat_strings},
 };
 
 use super::ElementHandler;

--- a/src/element_handler/blockquote.rs
+++ b/src/element_handler/blockquote.rs
@@ -1,6 +1,6 @@
 use crate::{
-    text_util::{concat_strings, JoinOnStringIterator, TrimAsciiWhitespace},
     Element,
+    text_util::{JoinOnStringIterator, TrimAsciiWhitespace, concat_strings},
 };
 
 pub(super) fn blockquote_handler(element: Element) -> Option<String> {

--- a/src/element_handler/br.rs
+++ b/src/element_handler/br.rs
@@ -1,4 +1,4 @@
-use crate::{options::BrStyle, Element};
+use crate::{Element, options::BrStyle};
 
 pub(super) fn br_handler(element: Element) -> Option<String> {
     match element.options.br_style {

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -4,10 +4,10 @@ use html5ever::Attribute;
 use markup5ever_rcdom::{Node, NodeData};
 
 use crate::{
+    Element,
     node_util::{get_node_tag_name, get_parent_node},
     options::{CodeBlockFence, CodeBlockStyle},
-    text_util::{concat_strings, JoinOnStringIterator, TrimAsciiWhitespace},
-    Element,
+    text_util::{JoinOnStringIterator, TrimAsciiWhitespace, concat_strings},
 };
 
 pub(super) fn code_handler(element: Element) -> Option<String> {

--- a/src/element_handler/emphasis.rs
+++ b/src/element_handler/emphasis.rs
@@ -1,6 +1,6 @@
 use crate::{
-    text_util::{concat_strings, StripWhitespace},
     Element,
+    text_util::{StripWhitespace, concat_strings},
 };
 
 pub(super) fn emphasis_handler(element: Element, marker: &str) -> Option<String> {

--- a/src/element_handler/headings.rs
+++ b/src/element_handler/headings.rs
@@ -1,4 +1,4 @@
-use crate::{options::HeadingStyle, text_util::TrimAsciiWhitespace, Element};
+use crate::{Element, options::HeadingStyle, text_util::TrimAsciiWhitespace};
 
 pub(super) fn headings_handler(element: Element) -> Option<String> {
     let level = element.tag.chars().nth(1).unwrap() as u32 - '0' as u32;

--- a/src/element_handler/hr.rs
+++ b/src/element_handler/hr.rs
@@ -1,4 +1,4 @@
-use crate::{options::HrStyle, Element};
+use crate::{Element, options::HrStyle};
 
 pub(super) fn hr_handler(element: Element) -> Option<String> {
     match element.options.hr_style {

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -1,6 +1,6 @@
 use crate::{
-    text_util::{concat_strings, JoinOnStringIterator, TrimAsciiWhitespace},
     Element,
+    text_util::{JoinOnStringIterator, TrimAsciiWhitespace, concat_strings},
 };
 
 pub(super) fn img_handler(element: Element) -> Option<String> {

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -1,8 +1,8 @@
 use crate::{
+    Element,
     node_util::get_node_tag_name,
     options::BulletListMarker,
-    text_util::{concat_strings, indent_text_except_first_line, TrimAsciiWhitespace},
-    Element,
+    text_util::{TrimAsciiWhitespace, concat_strings, indent_text_except_first_line},
 };
 use markup5ever_rcdom::NodeData;
 use std::rc::Rc;

--- a/src/element_handler/list.rs
+++ b/src/element_handler/list.rs
@@ -1,7 +1,7 @@
 use crate::{
+    Element,
     node_util::{get_node_tag_name, get_parent_node},
     text_util::concat_strings,
-    Element,
 };
 
 pub(super) fn list_handler(element: Element) -> Option<String> {

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -12,7 +12,7 @@ mod table;
 
 use crate::text_util::concat_strings;
 
-use super::{options::Options, Element};
+use super::{Element, options::Options};
 use anchor::AnchorElementHandler;
 use blockquote::blockquote_handler;
 use br::br_handler;

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -55,12 +55,12 @@ pub(crate) fn table_handler(element: Element) -> Option<String> {
                     }
                     "tbody" | "tfoot" => {
                         for row_node in get_node_children(&child) {
-                            if let NodeData::Element { name, .. } = &row_node.data {
-                                if name.local.as_ref() == "tr" {
-                                    let row_cells = extract_row_cells(&row_node, "td");
-                                    if !row_cells.is_empty() {
-                                        rows.push(row_cells);
-                                    }
+                            if let NodeData::Element { name, .. } = &row_node.data
+                                && name.local.as_ref() == "tr"
+                            {
+                                let row_cells = extract_row_cells(&row_node, "td");
+                                if !row_cells.is_empty() {
+                                    rows.push(row_cells);
                                 }
                             }
                         }
@@ -131,11 +131,11 @@ fn extract_row_cells(row_node: &Rc<markup5ever_rcdom::Node>, cell_tag: &str) -> 
     let mut cells = Vec::new();
 
     for cell_node in get_node_children(row_node) {
-        if let NodeData::Element { name, .. } = &cell_node.data {
-            if name.local.as_ref() == cell_tag {
-                let cell_content = get_node_content(&cell_node).trim().to_string();
-                cells.push(cell_content);
-            }
+        if let NodeData::Element { name, .. } = &cell_node.data
+            && name.local.as_ref() == cell_tag
+        {
+            let cell_content = get_node_content(&cell_node).trim().to_string();
+            cells.push(cell_content);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use dom_walker::walk_node;
 use element_handler::{ElementHandler, ElementHandlers};
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
-use html5ever::{parse_document, Attribute, ParseOpts};
+use html5ever::{Attribute, ParseOpts, parse_document};
 use markup5ever_rcdom::{Node, RcDom};
 use options::Options;
 

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,9 +1,8 @@
 use std::{sync::Arc, thread::JoinHandle};
 
 use htmd::{
-    convert,
+    Element, HtmlToMarkdown, convert,
     options::{BrStyle, LinkStyle, Options},
-    Element, HtmlToMarkdown,
 };
 
 #[test]

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -1,7 +1,6 @@
 use htmd::{
-    convert,
+    HtmlToMarkdown, convert,
     options::{LinkStyle, Options},
-    HtmlToMarkdown,
 };
 
 #[test]

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -1,4 +1,4 @@
-use htmd::{convert, options::Options, HtmlToMarkdown};
+use htmd::{HtmlToMarkdown, convert, options::Options};
 
 #[test]
 fn unordered_lists() {

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -1,9 +1,9 @@
 use htmd::{
+    HtmlToMarkdown,
     options::{
         BrStyle, BulletListMarker, CodeBlockFence, CodeBlockStyle, HeadingStyle, HrStyle,
         LinkReferenceStyle, LinkStyle, Options,
     },
-    HtmlToMarkdown,
 };
 use pretty_assertions::assert_eq;
 use scraper::{Html, Selector};

--- a/tests/turndown_online_demo_tests.rs
+++ b/tests/turndown_online_demo_tests.rs
@@ -1,6 +1,6 @@
 use htmd::{
-    options::{CodeBlockStyle, HeadingStyle, HrStyle, Options},
     HtmlToMarkdownBuilder,
+    options::{CodeBlockStyle, HeadingStyle, HrStyle, Options},
 };
 
 /// Contents are copied from https://mixmark-io.github.io/turndown/


### PR DESCRIPTION
Would you be willing to update to the Rust 2024 edition? It brings some really nice syntax improvements and simplifies some of the code you've written.

It looks like a huge PR, but it's 99% `cargo fmt`, with a bit of fixes for `cargo clippy` issues.