### PR TITLE
Fix: correct spacing between elements.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -80,15 +80,6 @@ fn append_text(
         let text = escape_if_needed(text);
         let text = compress_whitespace(&text);
 
-        let mut chars = text.chars();
-        if chars.next().is_some_and(|ch| ch == ' ')
-            && chars.next().is_none()
-            && parent_tag.is_some_and(is_block_container)
-        {
-            // Ignore whitespace in block containers.
-            return;
-        }
-
         let to_add = if trim_leading_spaces
             || (text.chars().next().is_some_and(|ch| ch == ' ')
                 && buffer.last().is_some_and(|text| text.ends_with(' ')))

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -43,7 +43,7 @@ fn images() {
         <img src="https://example.com" alt="Image 2" title="Hello" />
         "#;
     assert_eq!(
-        "![](https://example.com)![Image 1](https://example.com)\
+        "![](https://example.com) ![Image 1](https://example.com) \
             ![Image 2](https://example.com \"Hello\")",
         convert(html).unwrap(),
     )
@@ -144,7 +144,7 @@ fn hr() {
 
 #[test]
 fn strong_italic() {
-    let html = r#"<i>Italic</i> <em>Also italic</em> <strong>Strong</strong>"#;
+    let html = r#"<i>Italic</i><em>Also italic</em><strong>Strong</strong>"#;
     assert_eq!("_Italic__Also italic_**Strong**", convert(html).unwrap());
 }
 
@@ -180,7 +180,7 @@ fn with_head() {
         <body>
             Content
         </body>
-    </html> 
+    </html>
     "#;
     assert_eq!(
         "Demo\n\nconsole.log('Hello');\n\nbody {}\n\nContent",
@@ -250,7 +250,7 @@ fn multithreading() {
     <a href="https://example.com">Example</a>
     <a href="https://example.com">Example</a>
     "#;
-    let expected = "[Example][1][Example][2][Example][3][Example][4][Example][5]\n\n\
+    let expected = "[Example][1] [Example][2] [Example][3] [Example][4] [Example][5]\n\n\
     [1]: https://example.com\n[2]: https://example.com\n[3]: https://example.com\n\
     [4]: https://example.com\n[5]: https://example.com";
     let converter = HtmlToMarkdown::builder()

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -10,7 +10,7 @@ fn links() {
         <a href="https://example.com" title="Hello">Link 2</a>
         "#;
     assert_eq!(
-        "[Link 1](https://example.com)[Link 2](https://example.com \"Hello\")",
+        "[Link 1](https://example.com) [Link 2](https://example.com \"Hello\")",
         convert(html).unwrap(),
     );
 }


### PR DESCRIPTION
In the original code, HTML such as 

```HTML
<img src="https://example.com" />
<img src="https://example.com" alt="Image 1" />
<img src="https://example.com" alt="Image 2" title="Hello" />
```

was translated to Markdown with no whitespace between images:
```Markdown
![](https://example.com)![Image 1](https://example.com)![Image 2](https://example.com \"Hello\")"
```

However, any HTML whitespace should translate to at least one space in the resulting Markdown; this should be:
```Markdown
![](https://example.com) ![Image 1](https://example.com) ![Image 2](https://example.com \"Hello\")"
```

Likewise, no whitespace in HTML should produce no whitespace in the Markdown.
