### PR TITLE
Fix: combine adjacent similar elements.

### DIFF
--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,5 +1,7 @@
 use std::{sync::Arc, thread::JoinHandle};
 
+use pretty_assertions::assert_eq;
+
 use htmd::{
     Element, HtmlToMarkdown, convert,
     options::{BrStyle, LinkStyle, Options},
@@ -145,7 +147,13 @@ fn hr() {
 #[test]
 fn strong_italic() {
     let html = r#"<i>Italic</i><em>Also italic</em><strong>Strong</strong>"#;
-    assert_eq!("_Italic__Also italic_**Strong**", convert(html).unwrap());
+    assert_eq!("_ItalicAlso italic_**Strong**", convert(html).unwrap());
+}
+
+#[test]
+fn spaces_check() {
+    let html = r#"<i>Italic</i><em> Also italic</em>  <strong>Strong</strong>"#;
+    assert_eq!("_Italic Also italic_ **Strong**", convert(html).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
This fixes a subtle issue: when the same inline Markdown elements are adjacent, they should be combined:

```HTML
<i>Italic</i><em>Also italic</em><strong>Strong</strong>
```

should become

```Markdown
_ItalicAlso italic_**Strong**
```

Note that the "Italic" and "Also italic" are combined, since the incorrect translation `_Italic__Also italic_**Strong**` renders as _Italic__Also italic_**Strong**.