### PR TITLE
Fix: correctly escape raw HTML blocks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ readme = "README.md"
 html5ever = "0.35.0"
 markup5ever_rcdom = "0.35.0"
 html-escape = "0.2.13"
+const_format = "0.2.34"
+regex = "1.11.1"
+lazy_static = "1.5.0"
+indoc = "2.0.6"
 
 [dev-dependencies]
 scraper = "0.23.1"

--- a/tests/turndown_online_demo_tests.rs
+++ b/tests/turndown_online_demo_tests.rs
@@ -2,6 +2,7 @@ use htmd::{
     HtmlToMarkdownBuilder,
     options::{CodeBlockStyle, HeadingStyle, HrStyle, Options},
 };
+use pretty_assertions::assert_eq;
 
 /// Contents are copied from https://mixmark-io.github.io/turndown/
 #[test]


### PR DESCRIPTION
Last PR for now! I'm still working on code for future PRs.

This escapes raw HTML, such as:

```HTML
<p>&lt;pre</p>
<p>&lt;script</p>
<p>&lt;style</p>
<p>&lt;textarea</p>
<p>&lt;address</p>
<p>&lt;ul</p>
```

which should become:
```Markdown
\<pre

\<script

\<style

\<textarea

\<address

\<ul
```