### PR TITLE
Fix edge case in table header detection

### DIFF
--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -58,9 +58,21 @@ pub(crate) fn table_handler(element: Element) -> Option<String> {
                             if let NodeData::Element { name, .. } = &row_node.data
                                 && name.local.as_ref() == "tr"
                             {
-                                let row_cells = extract_row_cells(&row_node, "td");
-                                if !row_cells.is_empty() {
-                                    rows.push(row_cells);
+                                // If no thead is found, use the first row as headers
+                                if !has_thead && headers.is_empty() {
+                                    headers = extract_row_cells(&row_node, "th");
+                                    if headers.is_empty() {
+                                        let cells = extract_row_cells(&row_node, "td");
+                                        if !cells.is_empty() {
+                                            headers = cells;
+                                        }
+                                    }
+                                    has_thead = !headers.is_empty();
+                                } else {
+                                    let row_cells = extract_row_cells(&row_node, "td");
+                                    if !row_cells.is_empty() {
+                                        rows.push(row_cells);
+                                    }
                                 }
                             }
                         }

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -58,21 +58,19 @@ pub(crate) fn table_handler(element: Element) -> Option<String> {
                             if let NodeData::Element { name, .. } = &row_node.data
                                 && name.local.as_ref() == "tr"
                             {
-                                // If no thead is found, use the first row as headers
+                                // If no thead is found, use the first th row as header
                                 if !has_thead && headers.is_empty() {
                                     headers = extract_row_cells(&row_node, "th");
-                                    if headers.is_empty() {
-                                        let cells = extract_row_cells(&row_node, "td");
-                                        if !cells.is_empty() {
-                                            headers = cells;
-                                        }
-                                    }
                                     has_thead = !headers.is_empty();
-                                } else {
-                                    let row_cells = extract_row_cells(&row_node, "td");
-                                    if !row_cells.is_empty() {
-                                        rows.push(row_cells);
+
+                                    if has_thead {
+                                        continue;
                                     }
+                                }
+
+                                let row_cells = extract_row_cells(&row_node, "td");
+                                if !row_cells.is_empty() {
+                                    rows.push(row_cells);
                                 }
                             }
                         }

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -22,8 +22,10 @@ mod table_tests_1 {
         "#;
 
         let expected = r#"
-| Cell 1 | Cell 2 |
-| Cell 3 | Cell 4 |
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |
 "#
         .trim();
 


### PR DESCRIPTION
Hello,

I stumbled on an edge case on table conversion where the table header is not detected properly. The webpage is from Wikipedia (https://fr.wikipedia.org/wiki/Groupe_de_Lie#Groupes_de_Lie_r%C3%A9els_(groupes_de_Lie_classiques)), where a `table` has the header declared inside a `tbody` (I have no idea whether this is actually legit html)

So this PR simply copy-pastes the code doing  header detection from the `tr` section to the `tbody/tfoot` loop on `tr` children.

I'm not quite happy with the copy-pasta, yet I do not see a simple way around this (I tried factoring the code in a lambda but the borrow-checker yells at me since `header` is borrowed by the lambda and mutated in the other `match` arms)

Best regards,