### PR TITLE
Add: provide an an interface to the DOM tree, in addition to a string of HTML.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ use element_handler::{ElementHandler, ElementHandlers};
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
 use html5ever::{Attribute, ParseOpts, parse_document};
-use markup5ever_rcdom::{Node, RcDom};
+// Export publicly, providing an interface to the
+pub use markup5ever_rcdom::Node;
+use markup5ever_rcdom::RcDom;
 use options::Options;
 
 use crate::element_handler::Handlers;
@@ -120,8 +122,9 @@ impl HtmlToMarkdown {
         Ok(dom.document)
     }
 
-    /// Convert a DOM tree to Markdown.
-    pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> std::io::Result<String> {
+    /// Convert a DOM tree to Markdown. For convenience, `Node` is re-exported;
+    /// simply `use htmd::Node;` to access this type.
+    pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> String {
         let mut content = String::new();
 
         walk_node(tree, &mut content, &self.handlers, None, true, false);
@@ -138,12 +141,12 @@ impl HtmlToMarkdown {
 
         content.push_str(append.trim_end_matches('\n'));
 
-        Ok(content)
+        content
     }
 
     /// Convert HTML to Markdown.
     pub fn convert(&self, html: &str) -> std::io::Result<String> {
-        self.tree_to_markdown(&self.html_to_tree(html)?)
+        Ok(self.tree_to_markdown(&self.html_to_tree(html)?))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ impl HtmlToMarkdown {
         HtmlToMarkdownBuilder::new()
     }
 
-    /// Convert HTML to Markdown.
-    pub fn convert(&self, html: &str) -> std::io::Result<String> {
+    /// Convert HTML to a DOM tree.
+    pub fn html_to_tree(&self, html: &str) -> std::io::Result<Rc<Node>> {
         let dom = parse_document(
             RcDom::default(),
             ParseOpts {
@@ -117,16 +117,14 @@ impl HtmlToMarkdown {
         .from_utf8()
         .read_from(&mut html.as_bytes())?;
 
+        Ok(dom.document)
+    }
+
+    /// Convert a DOM tree to Markdown.
+    pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> std::io::Result<String> {
         let mut content = String::new();
 
-        walk_node(
-            &dom.document,
-            &mut content,
-            &self.handlers,
-            None,
-            true,
-            false,
-        );
+        walk_node(tree, &mut content, &self.handlers, None, true, false);
 
         let mut content = content.trim_matches(|ch| ch == '\n').to_string();
 
@@ -141,6 +139,11 @@ impl HtmlToMarkdown {
         content.push_str(append.trim_end_matches('\n'));
 
         Ok(content)
+    }
+
+    /// Convert HTML to Markdown.
+    pub fn convert(&self, html: &str) -> std::io::Result<String> {
+        self.tree_to_markdown(&self.html_to_tree(html)?)
     }
 }
 


### PR DESCRIPTION
This provides the `tree_to_markdown(&html_tree)` function, which converts from a DOM tree to markdown just as `convert(&html_str)` converts from HTML to markdown. It also provides the `let tree = html_to_tree(&html_str)` utility to convert between HTML and a DOM tree. This allows library users to modify the DOM tree after parsing but before before transforming it to Markdown. Without this, users needs to manipulate the HTML must parse, transform the DOM, render to a string, then pass the string to `convert`, which again parses the HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal HTML→Markdown conversion was modularized into separate parse and render steps for clearer structure and easier maintenance.
  * Conversion behavior and existing public convert API remain unchanged for end-users.
  * Improvements enable more predictable parsing and simplify future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->