### PR TITLE
Convert hotpath optimizations

### DIFF
--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -33,4 +33,4 @@ d300ee4	17.347	keep	baseline average of 3 sequential median-based runs after ben
 ca2c724	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2.85%)
 ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
 ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite
-1dd821b	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)
+5f244d5	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -34,4 +34,4 @@ ca2c724	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2
 ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
 ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite
 5f244d5	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)
-b756648	14.827	keep	drop MARKDOWN_BUF_HINT; String::new() (14.772, 14.884, 14.826; flat vs 14.794)
+0c311d2	14.827	keep	drop MARKDOWN_BUF_HINT; String::new() (14.772, 14.884, 14.826; flat vs 14.794)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -29,3 +29,7 @@ d300ee4	17.347	keep	baseline average of 3 sequential median-based runs after ben
 62eb1c2	16.180	discard	replace DOM mutation in can_combine with read-only temporary merged inline nodes
 2cd0014	15.808	keep	reduce anchor handler string churn in append/title/link formatting
 2cd0014	15.964	discard	simplify ordered-list assembly by mutating collected child strings in place
+396be33	15.401	keep	baseline back-to-back (15.354, 15.411, 15.436)
+wip	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2.85%)
+wip	14.776	discard	capacity heuristics + compress_whitespace rewrite
+wip	14.883	discard	can_combine early-exit reorder + table format rewrite

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -34,3 +34,4 @@ ca2c724	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2
 ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
 ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite
 5f244d5	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)
+b756648	14.827	keep	drop MARKDOWN_BUF_HINT; String::new() (14.772, 14.884, 14.826; flat vs 14.794)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -33,3 +33,4 @@ d300ee4	17.347	keep	baseline average of 3 sequential median-based runs after ben
 ca2c724	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2.85%)
 ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
 ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite
+1dd821b	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -30,6 +30,6 @@ d300ee4	17.347	keep	baseline average of 3 sequential median-based runs after ben
 2cd0014	15.808	keep	reduce anchor handler string churn in append/title/link formatting
 2cd0014	15.964	discard	simplify ordered-list assembly by mutating collected child strings in place
 396be33	15.401	keep	baseline back-to-back (15.354, 15.411, 15.436)
-wip	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2.85%)
-wip	14.776	discard	capacity heuristics + compress_whitespace rewrite
-wip	14.883	discard	can_combine early-exit reorder + table format rewrite
+ca2c724	14.962	keep	one-shot parse + walk micro-opts (14.944, 15.018, 14.926; -2.85%)
+ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
+ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -365,7 +365,7 @@ fn escape_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
         }
     }
 
-    if matches!(first, '0'..='9')
+    if first.is_ascii_digit()
         && let Some(dot_idx) = index_of_markdown_ordered_item_dot(&escaped)
     {
         escaped.replace_range(dot_idx..(dot_idx + 1), "\\.");

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -275,10 +275,9 @@ fn append_normalized_content(output: &mut String, mut content: String, is_pre: b
         return;
     }
 
-    // Newlines and spaces are ASCII, so byte scans are valid and cheaper than
-    // iterating `char`s.
-    let last_newlines = count_trailing_newlines(output.as_bytes());
-    let content_newlines = count_leading_newlines(content.as_bytes());
+    // Same newline-count idiom as `join_blocks`: len after trim_matches.
+    let last_newlines = output.len() - output.trim_end_matches('\n').len();
+    let content_newlines = content.len() - content.trim_start_matches('\n').len();
     let total_newlines = last_newlines + content_newlines;
 
     // Collapse excessive newlines (max 2)
@@ -291,23 +290,13 @@ fn append_normalized_content(output: &mut String, mut content: String, is_pre: b
     if !is_pre
         && last_newlines == 0
         && content_newlines == 0
-        && output.as_bytes().last() == Some(&b' ')
-        && content.as_bytes().first() == Some(&b' ')
+        && output.ends_with(' ')
+        && content.starts_with(' ')
     {
         content.remove(0);
     }
 
     output.push_str(&content);
-}
-
-#[inline]
-fn count_trailing_newlines(bytes: &[u8]) -> usize {
-    bytes.iter().rev().take_while(|&&b| b == b'\n').count()
-}
-
-#[inline]
-fn count_leading_newlines(bytes: &[u8]) -> usize {
-    bytes.iter().take_while(|&&b| b == b'\n').count()
 }
 
 fn trim_output_end(output: &mut String) {
@@ -349,11 +338,13 @@ fn escape_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
         return crate::html_escape::escape_html(text);
     }
 
-    // Decide whether a leading backslash is needed before building the string,
-    // so we never pay for `insert(0, ...)`.
+    // Decide structural leading escapes on the raw input before rewriting
+    // specials: the specials pass does not alter ATX `#` prefixes or the
+    // second-char space of list markers, so pre-escape checks match the old
+    // post-escape behavior without `insert(0, ...)`.
     let needs_leading_backslash = match first {
         '=' | '~' | '>' => true,
-        '-' | '+' => text.as_bytes().get(1) == Some(&b' '),
+        '-' | '+' => text.chars().nth(1) == Some(' '),
         '#' => is_markdown_atx_heading(text.as_ref()),
         _ => false,
     };

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -271,12 +271,14 @@ fn can_combine(n1: &Node, n2: &Node) -> Option<RefCell<Tendril<UTF8>>> {
 /// 2. Collapsing adjacent spaces between inline elements (when not in pre context)
 fn append_normalized_content(output: &mut String, mut content: String, is_pre: bool) {
     if output.is_empty() {
-        output.push_str(&content);
+        *output = content;
         return;
     }
 
-    let last_newlines = output.chars().rev().take_while(|c| *c == '\n').count();
-    let content_newlines = content.chars().take_while(|c| *c == '\n').count();
+    // Newlines and spaces are ASCII, so byte scans are valid and cheaper than
+    // iterating `char`s.
+    let last_newlines = count_trailing_newlines(output.as_bytes());
+    let content_newlines = count_leading_newlines(content.as_bytes());
     let total_newlines = last_newlines + content_newlines;
 
     // Collapse excessive newlines (max 2)
@@ -289,13 +291,23 @@ fn append_normalized_content(output: &mut String, mut content: String, is_pre: b
     if !is_pre
         && last_newlines == 0
         && content_newlines == 0
-        && output.ends_with(' ')
-        && content.chars().next().is_some_and(|c| c == ' ')
+        && output.as_bytes().last() == Some(&b' ')
+        && content.as_bytes().first() == Some(&b' ')
     {
         content.remove(0);
     }
 
     output.push_str(&content);
+}
+
+#[inline]
+fn count_trailing_newlines(bytes: &[u8]) -> usize {
+    bytes.iter().rev().take_while(|&&b| b == b'\n').count()
+}
+
+#[inline]
+fn count_leading_newlines(bytes: &[u8]) -> usize {
+    bytes.iter().take_while(|&&b| b == b'\n').count()
 }
 
 fn trim_output_end(output: &mut String) {
@@ -327,16 +339,29 @@ fn escape_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
     let mut need_escape = matches!(first, '=' | '~' | '>' | '-' | '+' | '#' | '0'..='9');
 
     if !need_escape {
+        // Markdown specials are all ASCII; byte scan avoids UTF-8 decoding.
         need_escape = text
-            .chars()
-            .any(|c| c == '\\' || c == '*' || c == '_' || c == '`' || c == '[' || c == ']');
+            .bytes()
+            .any(|b| matches!(b, b'\\' | b'*' | b'_' | b'`' | b'[' | b']'));
     }
 
     if !need_escape {
         return crate::html_escape::escape_html(text);
     }
 
-    let mut escaped = String::new();
+    // Decide whether a leading backslash is needed before building the string,
+    // so we never pay for `insert(0, ...)`.
+    let needs_leading_backslash = match first {
+        '=' | '~' | '>' => true,
+        '-' | '+' => text.as_bytes().get(1) == Some(&b' '),
+        '#' => is_markdown_atx_heading(text.as_ref()),
+        _ => false,
+    };
+
+    let mut escaped = String::with_capacity(text.len() + 8 + usize::from(needs_leading_backslash));
+    if needs_leading_backslash {
+        escaped.push('\\');
+    }
     for ch in text.chars() {
         match ch {
             '\\' => escaped.push_str("\\\\"),
@@ -349,26 +374,10 @@ fn escape_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
         }
     }
 
-    match first {
-        '=' | '~' | '>' => {
-            escaped.insert(0, '\\');
-        }
-        '-' | '+' => {
-            if escaped.chars().nth(1).is_some_and(|ch| ch == ' ') {
-                escaped.insert(0, '\\');
-            }
-        }
-        '#' => {
-            if is_markdown_atx_heading(&escaped) {
-                escaped.insert(0, '\\');
-            }
-        }
-        '0'..='9' => {
-            if let Some(dot_idx) = index_of_markdown_ordered_item_dot(&escaped) {
-                escaped.replace_range(dot_idx..(dot_idx + 1), "\\.");
-            }
-        }
-        _ => {}
+    if matches!(first, '0'..='9')
+        && let Some(dot_idx) = index_of_markdown_ordered_item_dot(&escaped)
+    {
+        escaped.replace_range(dot_idx..(dot_idx + 1), "\\.");
     }
 
     // Perform the HTML escape after the other escapes, so that the \\

--- a/src/element_handler/caption.rs
+++ b/src/element_handler/caption.rs
@@ -10,7 +10,7 @@ pub(super) fn caption_handler(handlers: &dyn Handlers, element: Element) -> Opti
     handle_or_serialize_by_parent(
         handlers,
         &element,
-        &vec!["table"],
+        &["table"],
         element.markdown_translated,
     )
 }

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -119,20 +119,17 @@ fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<Handl
     let mut surround_with_spaces = false;
     let content = handlers.walk_children(element.node).content;
     // Scan for an isolated backtick without allocating a `Vec<char>`.
-    {
-        let bytes = content.as_bytes();
-        let mut i = 0;
-        while i < bytes.len() {
-            if bytes[i] == b'`' {
-                let prev = if i > 0 { bytes[i - 1] } else { 0 };
-                let next = bytes.get(i + 1).copied().unwrap_or(0);
-                if prev != b'`' && next != b'`' {
-                    use_double_backticks = true;
-                    surround_with_spaces = i == 0;
-                    break;
-                }
-            }
-            i += 1;
+    let bytes = content.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'`' {
+            continue;
+        }
+        let prev = if i > 0 { bytes[i - 1] } else { 0 };
+        let next = bytes.get(i + 1).copied().unwrap_or(0);
+        if prev != b'`' && next != b'`' {
+            use_double_backticks = true;
+            surround_with_spaces = i == 0;
+            break;
         }
     }
     let content = if handlers.options().preformatted_code {

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -118,17 +118,21 @@ fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<Handl
     //   to: `` `starting with a backtick ``
     let mut surround_with_spaces = false;
     let content = handlers.walk_children(element.node).content;
-    let chars = content.chars().collect::<Vec<char>>();
-    let len = chars.len();
-    for (idx, c) in chars.iter().enumerate() {
-        if c == &'`' {
-            let prev = if idx > 0 { chars[idx - 1] } else { '\0' };
-            let next = if idx < len - 1 { chars[idx + 1] } else { '\0' };
-            if prev != '`' && next != '`' {
-                use_double_backticks = true;
-                surround_with_spaces = idx == 0;
-                break;
+    // Scan for an isolated backtick without allocating a `Vec<char>`.
+    {
+        let bytes = content.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'`' {
+                let prev = if i > 0 { bytes[i - 1] } else { 0 };
+                let next = bytes.get(i + 1).copied().unwrap_or(0);
+                if prev != b'`' && next != b'`' {
+                    use_double_backticks = true;
+                    surround_with_spaces = i == 0;
+                    break;
+                }
             }
+            i += 1;
         }
     }
     let content = if handlers.options().preformatted_code {

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -18,7 +18,7 @@ pub(super) fn handle_or_serialize_by_parent(
     // The element to check.
     element: &Element,
     // A list of allowable tag names for this element's parent.
-    tag_names: &Vec<&str>,
+    tag_names: &[&str],
     // The value for `markdown_translate` to pass if this tag is markdown translatable.
     markdown_translated: bool,
 ) -> Option<HandlerResult> {

--- a/src/element_handler/head_body.rs
+++ b/src/element_handler/head_body.rs
@@ -8,5 +8,5 @@ pub(super) fn head_body_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    handle_or_serialize_by_parent(handlers, &element, &vec!["html"], true)
+    handle_or_serialize_by_parent(handlers, &element, &["html"], true)
 }

--- a/src/element_handler/tbody.rs
+++ b/src/element_handler/tbody.rs
@@ -12,7 +12,7 @@ pub(super) fn tbody_handler(handlers: &dyn Handlers, element: Element) -> Option
     handle_or_serialize_by_parent(
         handlers,
         &element,
-        &vec!["table"],
+        &["table"],
         element.markdown_translated,
     )
 }

--- a/src/element_handler/td_th.rs
+++ b/src/element_handler/td_th.rs
@@ -23,5 +23,5 @@ pub(super) fn td_th_handler(handlers: &dyn Handlers, element: Element) -> Option
         // block elements.
         if has_block_elements { -1 } else { 0 }
     );
-    handle_or_serialize_by_parent(handlers, &element, &vec!["tr"], true)
+    handle_or_serialize_by_parent(handlers, &element, &["tr"], true)
 }

--- a/src/element_handler/thead.rs
+++ b/src/element_handler/thead.rs
@@ -12,7 +12,7 @@ pub(super) fn thead_handler(handlers: &dyn Handlers, element: Element) -> Option
     handle_or_serialize_by_parent(
         handlers,
         &element,
-        &vec!["table"],
+        &["table"],
         element.markdown_translated,
     )
 }

--- a/src/element_handler/tr.rs
+++ b/src/element_handler/tr.rs
@@ -12,7 +12,7 @@ pub(super) fn tr_handler(handlers: &dyn Handlers, element: Element) -> Option<Ha
     handle_or_serialize_by_parent(
         handlers,
         &element,
-        &vec!["tbody", "thead"],
+        &["tbody", "thead"],
         element.markdown_translated,
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,10 +128,7 @@ impl HtmlToMarkdown {
     /// Convert a DOM tree to Markdown. For convenience, `Node` is re-exported;
     /// simply `use htmd::Node;` to access this type.
     pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> String {
-        // Initial markdown buffer size. Large pages grow past this; it only
-        // avoids a few early reallocations on medium/large docs.
-        const MARKDOWN_BUF_HINT: usize = 4096;
-        let mut content = String::with_capacity(MARKDOWN_BUF_HINT);
+        let mut content = String::new();
 
         walk_node(tree, &mut content, &self.handlers, None, true, false);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,9 +128,10 @@ impl HtmlToMarkdown {
     /// Convert a DOM tree to Markdown. For convenience, `Node` is re-exported;
     /// simply `use htmd::Node;` to access this type.
     pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> String {
-        // Modest default capacity to cut early reallocations on large docs
-        // without over-allocating on tiny inputs.
-        let mut content = String::with_capacity(4096);
+        // Initial markdown buffer size. Large pages grow past this; it only
+        // avoids a few early reallocations on medium/large docs.
+        const MARKDOWN_BUF_HINT: usize = 4096;
+        let mut content = String::with_capacity(MARKDOWN_BUF_HINT);
 
         walk_node(tree, &mut content, &self.handlers, None, true, false);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,10 @@ impl HtmlToMarkdown {
 
     /// Convert HTML to a DOM tree.
     pub fn html_to_tree(&self, html: &str) -> std::io::Result<Rc<Node>> {
+        // Feed the whole UTF-8 string to the parser in one shot. This avoids
+        // the 4 KiB chunked `read_from` path and the UTF-8 lossy decoder layer
+        // used by `from_utf8()`, both of which add overhead when the input is
+        // already a valid `&str`.
         let dom = parse_document(
             RcDom::default(),
             ParseOpts {
@@ -116,8 +120,7 @@ impl HtmlToMarkdown {
                 ..Default::default()
             },
         )
-        .from_utf8()
-        .read_from(&mut html.as_bytes())?;
+        .one(html);
 
         Ok(dom.document)
     }
@@ -125,11 +128,19 @@ impl HtmlToMarkdown {
     /// Convert a DOM tree to Markdown. For convenience, `Node` is re-exported;
     /// simply `use htmd::Node;` to access this type.
     pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> String {
-        let mut content = String::new();
+        // Modest default capacity to cut early reallocations on large docs
+        // without over-allocating on tiny inputs.
+        let mut content = String::with_capacity(4096);
 
         walk_node(tree, &mut content, &self.handlers, None, true, false);
 
-        let mut content = content.trim_matches(|ch| ch == '\n').to_string();
+        // Trim leading/trailing newlines in place instead of allocating a copy.
+        let start = content.len() - content.trim_start_matches('\n').len();
+        if start > 0 {
+            content.drain(..start);
+        }
+        let end = content.trim_end_matches('\n').len();
+        content.truncate(end);
 
         let mut append = String::new();
         for handler in &self.handlers.handlers {

--- a/src/node_util.rs
+++ b/src/node_util.rs
@@ -24,7 +24,7 @@ pub(crate) fn get_parent_node(node: &Rc<Node>) -> Option<Rc<Node>> {
 }
 
 // Check to see if node's parent's tag name matches the provided string.
-pub(crate) fn parent_tag_name_equals(node: &Rc<Node>, tag_names: &Vec<&str>) -> bool {
+pub(crate) fn parent_tag_name_equals(node: &Rc<Node>, tag_names: &[&str]) -> bool {
     if let Some(parent) = get_parent_node(node)
         && let Some(actual_tag_name) = get_node_tag_name(&parent)
         && tag_names.contains(&actual_tag_name)
@@ -36,6 +36,5 @@ pub(crate) fn parent_tag_name_equals(node: &Rc<Node>, tag_names: &Vec<&str>) -> 
 }
 
 pub(crate) fn get_node_children(node: &Rc<Node>) -> Vec<Rc<Node>> {
-    let children = node.children.borrow();
-    children.iter().cloned().collect()
+    node.children.borrow().iter().cloned().collect()
 }

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -211,8 +211,9 @@ pub(crate) fn compress_whitespace(input: &str) -> Cow<'_, str> {
 // Per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Text/Whitespace),
 // document white space characters only include spaces, tabs, line
 // feeds, and newlines. Remove only these from the end of a line.
+#[inline]
 fn is_document_whitespace(c: char) -> bool {
-    ['\t', '\n', '\r', ' '].contains(&c)
+    matches!(c, '\t' | '\n' | '\r' | ' ')
 }
 
 pub(crate) fn indent_text_except_first_line(


### PR DESCRIPTION
The optimizations from AI show a 3.9% improvement in the benchmark result: 

15.401ms -> 14.794ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved HTML-to-Markdown conversion efficiency by reducing temporary allocations during parsing and serialization.
  * Faster processing for whitespace normalization, inline code formatting, and Markdown character escaping.

* **Compatibility**
  * Preserved existing output while refining edge-case handling for newlines, leading spaces, and Markdown marker escaping (including ordered lists).

* **Refactor**
  * Streamlined internal tag/selector handling and simplified whitespace detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->