### PR TITLE
Autoresearch r2

### DIFF
--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -42,3 +42,4 @@ a36f2d3	14.968	discard	fixed built-in dispatch combined with raw span fast path;
 a36f2d3	14.912	discard	raw pure-span fast path (14.888, 14.922, 14.926; behavior regression for nested block content)
 a36f2d3	14.976	keep	bypass ordinary pure-span dispatch while preserving newline normalization (14.929, 15.012, 14.985; cv 0.23%; -2.89%)
 20cae17	14.842	keep	reuse owned href allocation when no destination escaping is needed (14.809, 14.837, 14.879; cv 0.19%; -0.89%)
+6cf71f0	14.793	keep	trim owned list-item content in place (14.762, 14.821, 14.797; cv 0.17%; -0.33%)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -35,3 +35,9 @@ ca2c724	14.776	discard	capacity heuristics + compress_whitespace rewrite
 ca2c724	14.883	discard	can_combine early-exit reorder + table format rewrite
 5f244d5	14.794	keep	review cleanup: house-style newline counts, named MARKDOWN_BUF_HINT, clearer code/escape (14.710, 14.801, 14.871)
 0c311d2	14.827	keep	drop MARKDOWN_BUF_HINT; String::new() (14.772, 14.884, 14.826; flat vs 14.794)
+a36f2d3	15.421	keep	autoresearch-r2 baseline (15.382, 15.401, 15.482; cv 0.28%)
+a36f2d3	15.501	discard	reuse a static default converter in convert() (15.391, 15.593, 15.519; cv 0.54%)
+a36f2d3	15.983	discard	avoid borrowing children for ordinary non-math span classes (16.103, 15.890, 15.957; cv 0.56%)
+a36f2d3	14.968	discard	fixed built-in dispatch combined with raw span fast path; slower than isolated raw span path (14.899, 14.968, 15.036)
+a36f2d3	14.912	discard	raw pure-span fast path (14.888, 14.922, 14.926; behavior regression for nested block content)
+a36f2d3	14.976	keep	bypass ordinary pure-span dispatch while preserving newline normalization (14.929, 15.012, 14.985; cv 0.23%; -2.89%)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -41,3 +41,4 @@ a36f2d3	15.983	discard	avoid borrowing children for ordinary non-math span class
 a36f2d3	14.968	discard	fixed built-in dispatch combined with raw span fast path; slower than isolated raw span path (14.899, 14.968, 15.036)
 a36f2d3	14.912	discard	raw pure-span fast path (14.888, 14.922, 14.926; behavior regression for nested block content)
 a36f2d3	14.976	keep	bypass ordinary pure-span dispatch while preserving newline normalization (14.929, 15.012, 14.985; cv 0.23%; -2.89%)
+20cae17	14.842	keep	reuse owned href allocation when no destination escaping is needed (14.809, 14.837, 14.879; cv 0.19%; -0.89%)

--- a/benches/results.tsv
+++ b/benches/results.tsv
@@ -43,3 +43,5 @@ a36f2d3	14.912	discard	raw pure-span fast path (14.888, 14.922, 14.926; behavior
 a36f2d3	14.976	keep	bypass ordinary pure-span dispatch while preserving newline normalization (14.929, 15.012, 14.985; cv 0.23%; -2.89%)
 20cae17	14.842	keep	reuse owned href allocation when no destination escaping is needed (14.809, 14.837, 14.879; cv 0.19%; -0.89%)
 6cf71f0	14.793	keep	trim owned list-item content in place (14.762, 14.821, 14.797; cv 0.17%; -0.33%)
+75c6835	14.584	keep	bypass fallback dispatch for unhandled pure-mode elements (recheck 14.598, 14.576, 14.578; cv 0.07%; -1.41%; initial noisy avg 14.756)
+c89d210	14.565	discard	single-allocation formatting for one-line unordered-list items; flat vs 14.584 ms (14.545, 14.565, 14.586; cv 0.12%)

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -82,14 +82,32 @@ pub(crate) fn walk_node(
             // Visit this element.
             let tag = &*name.local;
             let is_head = tag == "head";
+            let attrs = attrs.borrow();
 
-            let res = handlers.handle(
-                node,
-                tag,
-                &attrs.borrow(),
-                true, // Default to true, handler will update
-                0,
-            );
+            if tag == "span"
+                && handlers.options.translation_mode == TranslationMode::Pure
+                && handlers
+                    .tag_to_handler_indices
+                    .get("span")
+                    .is_some_and(|indices| indices.len() == 1)
+                && !is_math_span(&attrs)
+            {
+                let mut content = String::new();
+                let markdown_translated =
+                    walk_children(node, &mut content, handlers, false, is_pre);
+
+                let start = content.len() - content.trim_start_matches('\n').len();
+                if start > 0 {
+                    content.drain(..start);
+                }
+                let end = content.trim_end_matches('\n').len();
+                content.truncate(end);
+
+                append_normalized_content(output, content, is_pre);
+                return markdown_translated;
+            }
+
+            let res = handlers.handle(node, tag, &attrs, true, 0);
 
             if let Some(res) = res {
                 markdown_translated = res.markdown_translated;
@@ -111,6 +129,15 @@ pub(crate) fn walk_node(
     }
 
     markdown_translated
+}
+
+fn is_math_span(attrs: &[html5ever::Attribute]) -> bool {
+    attrs.len() == 1
+        && attrs[0].name.local.as_ref() == "class"
+        && matches!(
+            attrs[0].value.as_ref(),
+            "math math-inline" | "math math-display"
+        )
 }
 
 fn is_plain_text(text: &str) -> bool {

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -107,6 +107,16 @@ pub(crate) fn walk_node(
                 return markdown_translated;
             }
 
+            if handlers.options.translation_mode == TranslationMode::Pure
+                && !handlers.tag_to_handler_indices.contains_key(tag)
+            {
+                let mut content = String::new();
+                let markdown_translated =
+                    walk_children(node, &mut content, handlers, is_block_element(tag), is_pre);
+                append_normalized_content(output, content, is_pre);
+                return markdown_translated;
+            }
+
             let res = handlers.handle(node, tag, &attrs, true, 0);
 
             if let Some(res) = res {

--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -93,6 +93,8 @@ pub(crate) fn walk_node(
                 && !is_math_span(&attrs)
             {
                 let mut content = String::new();
+                let is_pre =
+                    is_pre || (parent_tag.is_none() && crate::element_handler::is_inside_pre(node));
                 let markdown_translated =
                     walk_children(node, &mut content, handlers, false, is_pre);
 
@@ -111,6 +113,8 @@ pub(crate) fn walk_node(
                 && !handlers.tag_to_handler_indices.contains_key(tag)
             {
                 let mut content = String::new();
+                let is_pre =
+                    is_pre || (parent_tag.is_none() && crate::element_handler::is_inside_pre(node));
                 let markdown_translated =
                     walk_children(node, &mut content, handlers, is_block_element(tag), is_pre);
                 append_normalized_content(output, content, is_pre);

--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -60,7 +60,7 @@ impl ElementHandler for AnchorElementHandler {
         // Handle new lines in title
         let title = title.map(|text| process_title(&text));
 
-        let link = escape_link_destination(&link);
+        let link = escape_link_destination(link);
 
         let content = handlers.walk_children(element.node).content;
         let md = match handlers.options().link_style {
@@ -167,9 +167,9 @@ impl AnchorElementHandler {
     }
 }
 
-fn escape_link_destination(link: &str) -> String {
+fn escape_link_destination(link: String) -> String {
     if !link.contains(['(', ')']) {
-        return link.to_string();
+        return link;
     }
 
     let mut escaped = String::with_capacity(link.len());

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -12,11 +12,11 @@ pub(super) fn list_item_handler(
     element: Element,
 ) -> Option<HandlerResult> {
     serialize_if_faithful!(handlers, element, 0);
-    let content = handlers
-        .walk_children(element.node)
-        .content
-        .trim_start_document_whitespace()
-        .to_string();
+    let mut content = handlers.walk_children(element.node).content;
+    let start = content.len() - content.trim_start_document_whitespace().len();
+    if start > 0 {
+        content.drain(..start);
+    }
 
     let ul_li = || {
         let marker = if handlers.options().bullet_list_marker == BulletListMarker::Asterisk {

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -355,7 +355,7 @@ impl Handlers for ElementHandlers {
     }
 }
 
-fn is_inside_pre(node: &Rc<Node>) -> bool {
+pub(crate) fn is_inside_pre(node: &Rc<Node>) -> bool {
     let mut current = crate::node_util::get_parent_node(node);
     while let Some(parent) = current {
         if let Some(tag) = crate::node_util::get_node_tag_name(&parent)

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,15 +1,29 @@
-use std::{sync::Arc, thread::JoinHandle};
+use std::{rc::Rc, sync::Arc, thread::JoinHandle};
 
 use indoc::indoc;
+use markup5ever_rcdom::NodeData;
 use pretty_assertions::assert_eq;
 
 use htmd::{
-    Element, HtmlToMarkdown,
+    Element, HtmlToMarkdown, Node,
     element_handler::Handlers,
     options::{BrStyle, LinkStyle, Options, TranslationMode},
 };
 mod common;
 use common::convert;
+
+fn find_element(node: &Rc<Node>, tag: &str) -> Option<Rc<Node>> {
+    if let NodeData::Element { name, .. } = &node.data
+        && name.local.as_ref() == tag
+    {
+        return Some(node.clone());
+    }
+
+    node.children
+        .borrow()
+        .iter()
+        .find_map(|child| find_element(child, tag))
+}
 
 #[test]
 fn links_with_spaces() {
@@ -137,6 +151,37 @@ fn code_blocks_with_lang_class_on_pre_tag() {
     assert_eq!(
         "```rust\nprintln!(\"Hello\");\n```",
         htmd::convert(html).unwrap()
+    );
+}
+
+#[test]
+fn span_subtree_conversion_preserves_ancestor_preformatted_context() {
+    let converter = HtmlToMarkdown::new();
+    let tree = converter
+        .html_to_tree("<pre><span>  *literal*  \nsecond</span></pre>")
+        .unwrap();
+    let span = find_element(&tree, "span").unwrap();
+
+    assert_eq!("  *literal*  \nsecond", converter.tree_to_markdown(&span));
+}
+
+#[test]
+fn delegated_unhandled_subtree_preserves_ancestor_preformatted_context() {
+    let converter = HtmlToMarkdown::builder()
+        .add_handler(
+            vec!["delegate"],
+            |handlers: &dyn Handlers, element: Element| {
+                let child = element.node.children.borrow().first()?.clone();
+                handlers.handle(&child)
+            },
+        )
+        .build();
+
+    assert_eq!(
+        "  *literal*  \nsecond",
+        converter
+            .convert("<pre><delegate><mark>  *literal*  \nsecond</mark></delegate></pre>")
+            .unwrap()
     );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pure translation mode handling for spans and unsupported elements while preserving normalized content.
  * Preserved preformatted content when converting nested elements and delegated subtrees.
  * Improved rendering of links containing parentheses.
  * Fixed whitespace handling in ordered and unordered list items.
* **Tests**
  * Added coverage for preformatted content preservation and delegated element handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->