### PR TITLE
Fix Markdown parsing edge cases

### DIFF
--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -83,17 +83,23 @@ fn handle_code_block(
 }
 
 fn get_code_fence_marker(symbol: &str, content: &str) -> String {
-    let three_chars = symbol.repeat(3);
-    if content.contains(&three_chars) {
-        let four_chars = symbol.repeat(4);
-        if content.contains(&four_chars) {
-            symbol.repeat(5)
+    let symbol = symbol
+        .chars()
+        .next()
+        .expect("code fence symbol cannot be empty");
+    let mut longest_run = 0;
+    let mut current_run = 0;
+
+    for ch in content.chars() {
+        if ch == symbol {
+            current_run += 1;
+            longest_run = longest_run.max(current_run);
         } else {
-            four_chars
+            current_run = 0;
         }
-    } else {
-        three_chars
     }
+
+    symbol.to_string().repeat(3.max(longest_run + 1))
 }
 
 fn find_language_from_attrs(attrs: &[Attribute]) -> Option<String> {
@@ -111,41 +117,46 @@ fn find_language_from_attrs(attrs: &[Attribute]) -> Option<String> {
 
 fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_faithful!(handlers, element, 0);
-    // Case: <code>There is a literal backtick (`) here</code>
-    //   to: ``There is a literal backtick (`) here``
-    let mut use_double_backticks = false;
-    // Case: <code>`starting with a backtick</code>
-    //   to: `` `starting with a backtick ``
-    let mut surround_with_spaces = false;
     let content = handlers.walk_children(element.node).content;
-    // Scan for an isolated backtick without allocating a `Vec<char>`.
-    let bytes = content.as_bytes();
-    for (i, &b) in bytes.iter().enumerate() {
-        if b != b'`' {
-            continue;
-        }
-        let prev = if i > 0 { bytes[i - 1] } else { 0 };
-        let next = bytes.get(i + 1).copied().unwrap_or(0);
-        if prev != b'`' && next != b'`' {
-            use_double_backticks = true;
-            surround_with_spaces = i == 0;
-            break;
-        }
-    }
     let content = if handlers.options().preformatted_code {
         handle_preformatted_code(&content)
     } else {
         content.trim_document_whitespace().to_string()
     };
-    if use_double_backticks {
-        if surround_with_spaces {
-            Some(concat_strings!("`` ", content, " ``").into())
-        } else {
-            Some(concat_strings!("``", content, "``").into())
-        }
+
+    let delimiter = get_inline_code_delimiter(&content);
+    if content.starts_with('`') || content.ends_with('`') {
+        Some(concat_strings!(delimiter, " ", content, " ", delimiter).into())
     } else {
-        Some(concat_strings!("`", content, "`").into())
+        Some(concat_strings!(delimiter, content, delimiter).into())
     }
+}
+
+fn get_inline_code_delimiter(content: &str) -> String {
+    let mut run_lengths = Vec::new();
+    let mut current_run = 0;
+    let mut longest_run = 0;
+
+    for byte in content.bytes() {
+        if byte == b'`' {
+            current_run += 1;
+            longest_run = longest_run.max(current_run);
+        } else if current_run > 0 {
+            run_lengths.push(current_run);
+            current_run = 0;
+        }
+    }
+    if current_run > 0 {
+        run_lengths.push(current_run);
+    }
+
+    let delimiter_len = if content.starts_with('`') || content.ends_with('`') {
+        longest_run + 1
+    } else {
+        (1..).find(|length| !run_lengths.contains(length)).unwrap()
+    };
+
+    "`".repeat(delimiter_len)
 }
 
 /// Newlines become spaces (+ an extra space if not in the middle of the code)

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -118,6 +118,10 @@ fn find_language_from_attrs(attrs: &[Attribute]) -> Option<String> {
 fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_faithful!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
+    let preserve_boundary_spaces = handlers.options().preformatted_code
+        && content.starts_with(' ')
+        && content.ends_with(' ')
+        && !content.trim_matches(' ').is_empty();
     let content = if handlers.options().preformatted_code {
         handle_preformatted_code(&content)
     } else {
@@ -125,7 +129,9 @@ fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<Handl
     };
 
     let delimiter = get_inline_code_delimiter(&content);
-    if content.starts_with('`') || content.ends_with('`') {
+    let needs_padding =
+        content.starts_with('`') || content.ends_with('`') || preserve_boundary_spaces;
+    if needs_padding {
         Some(concat_strings!(delimiter, " ", content, " ", delimiter).into())
     } else {
         Some(concat_strings!(delimiter, content, delimiter).into())

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -49,10 +49,10 @@ pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<H
         "](",
         if has_spaces_in_link { "<" } else { "" },
         link.as_ref().unwrap_or(&String::new()),
+        if has_spaces_in_link { ">" } else { "" },
         title
             .as_ref()
             .map_or(String::new(), |t| concat_strings!(" \"", t, "\"")),
-        if has_spaces_in_link { ">" } else { "" },
         ")"
     );
     Some(md.into())

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -148,11 +148,9 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
     }
 
     // Determine the number of columns by finding the max column count
-    let num_columns = if headers.is_empty() {
-        rows.iter().map(|row| row.len()).max().unwrap_or(0)
-    } else {
-        headers.len()
-    };
+    let num_columns = headers
+        .len()
+        .max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
 
     if num_columns == 0 {
         let content = handlers.walk_children(element.node).content;

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,29 +1,15 @@
-use std::{rc::Rc, sync::Arc, thread::JoinHandle};
+use std::{sync::Arc, thread::JoinHandle};
 
 use indoc::indoc;
-use markup5ever_rcdom::NodeData;
 use pretty_assertions::assert_eq;
 
 use htmd::{
-    Element, HtmlToMarkdown, Node,
+    Element, HtmlToMarkdown,
     element_handler::Handlers,
     options::{BrStyle, LinkStyle, Options, TranslationMode},
 };
 mod common;
 use common::convert;
-
-fn find_element(node: &Rc<Node>, tag: &str) -> Option<Rc<Node>> {
-    if let NodeData::Element { name, .. } = &node.data
-        && name.local.as_ref() == tag
-    {
-        return Some(node.clone());
-    }
-
-    node.children
-        .borrow()
-        .iter()
-        .find_map(|child| find_element(child, tag))
-}
 
 #[test]
 fn links_with_spaces() {
@@ -135,67 +121,6 @@ fn headings() {
              #### Heading 4\n\n##### Heading 5\n\n###### Heading 6",
         convert(html).unwrap(),
     )
-}
-
-#[test]
-fn code_blocks() {
-    let html = r#"
-        <pre><code>println!("Hello");</code></pre>
-        "#;
-    assert_eq!("```\nprintln!(\"Hello\");\n```", convert(html).unwrap());
-}
-
-#[test]
-fn code_blocks_with_lang_class() {
-    let html = r#"
-        <pre><code class="language-rust">println!("Hello");</code></pre>
-        "#;
-    assert_eq!("```rust\nprintln!(\"Hello\");\n```", convert(html).unwrap());
-}
-
-// See https://github.com/letmutex/htmd/issues/14 for background on this test --
-// the `class` attribute is deliberately misplaced to support Markdown renderers
-// which don't follow the CommonMark spec.
-#[test]
-fn code_blocks_with_lang_class_on_pre_tag() {
-    let html = r#"
-        <pre class="language-rust"><code>println!("Hello");</code></pre>
-        "#;
-    assert_eq!(
-        "```rust\nprintln!(\"Hello\");\n```",
-        htmd::convert(html).unwrap()
-    );
-}
-
-#[test]
-fn span_subtree_conversion_preserves_ancestor_preformatted_context() {
-    let converter = HtmlToMarkdown::new();
-    let tree = converter
-        .html_to_tree("<pre><span>  *literal*  \nsecond</span></pre>")
-        .unwrap();
-    let span = find_element(&tree, "span").unwrap();
-
-    assert_eq!("  *literal*  \nsecond", converter.tree_to_markdown(&span));
-}
-
-#[test]
-fn delegated_unhandled_subtree_preserves_ancestor_preformatted_context() {
-    let converter = HtmlToMarkdown::builder()
-        .add_handler(
-            vec!["delegate"],
-            |handlers: &dyn Handlers, element: Element| {
-                let child = element.node.children.borrow().first()?.clone();
-                handlers.handle(&child)
-            },
-        )
-        .build();
-
-    assert_eq!(
-        "  *literal*  \nsecond",
-        converter
-            .convert("<pre><delegate><mark>  *literal*  \nsecond</mark></delegate></pre>")
-            .unwrap()
-    );
 }
 
 #[test]
@@ -377,33 +302,6 @@ fn faithful_mode_p() {
     assert_eq!(
         convert(indoc!(r#"<p dir="ltr">Test 1</p>"#)).unwrap(),
         indoc!(r#"<p dir="ltr">Test 1</p>"#)
-    );
-}
-
-#[test]
-fn faithful_mode_pre() {
-    assert_eq!(
-        convert(indoc!(r#"<pre>Test</pre>"#)).unwrap(),
-        indoc!(r#"<pre>Test</pre>"#)
-    );
-}
-
-#[test]
-fn faithful_mode_code_block1() {
-    assert_eq!(
-        convert(indoc!(r#"<pre><code accesskey="f">Test</code></pre>"#)).unwrap(),
-        indoc!(r#"<pre><code accesskey="f">Test</code></pre>"#)
-    );
-}
-
-#[test]
-fn faithful_mode_code_block2() {
-    assert_eq!(
-        convert(indoc!(
-            r#"<pre><code class="language-ruby"><i>Test</i></code></pre>"#
-        ))
-        .unwrap(),
-        indoc!(r#"<pre><code class="language-ruby"><i>Test</i></code></pre>"#)
     );
 }
 
@@ -646,9 +544,6 @@ fn html_entities() {
         r#"This & that, then < > now."#,
         convert(html_plain).unwrap()
     );
-
-    let html_pre = r#"<pre><code>let x = 5 &amp;&amp; y &lt; 10;</code></pre>"#;
-    assert_eq!("```\nlet x = 5 && y < 10;\n```", convert(html_pre).unwrap());
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -108,6 +108,19 @@ fn images_with_spaces_in_url() {
 }
 
 #[test]
+fn image_title_stays_outside_an_angle_bracket_destination() {
+    let markdown = htmd::convert(
+        r#"<img src="https://example.com/image name.png" alt="diagram" title="A title">"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        r#"![diagram](<https://example.com/image name.png> "A title")"#,
+        markdown
+    );
+}
+
+#[test]
 fn headings() {
     let html = r#"
         <h1>Heading 1</h1>
@@ -696,6 +709,13 @@ fn multithreading() {
 fn unterminated_html() {
     // The `<i>` tag isn't terminated. Make sure the conversion still works.
     assert_eq!("# *A*", convert("<h1><i>A</h1>").unwrap());
+}
+
+#[test]
+fn misnested_formatting_does_not_duplicate_or_lose_text() {
+    let markdown = htmd::convert("<p><b>one<i>two</b>three</i>four").unwrap();
+
+    assert_eq!("**one*two****three*four", markdown);
 }
 
 #[test]

--- a/tests/code_tests.rs
+++ b/tests/code_tests.rs
@@ -1,0 +1,43 @@
+use htmd::{
+    HtmlToMarkdown,
+    options::{CodeBlockFence, Options},
+};
+use pretty_assertions::assert_eq;
+
+#[test]
+fn inline_code_made_only_of_backticks_uses_a_non_colliding_delimiter() {
+    let markdown = htmd::convert("<code>``</code>").unwrap();
+
+    assert_eq!("``` `` ```", markdown);
+}
+
+#[test]
+fn inline_code_ending_in_a_backtick_keeps_the_backtick_inside_the_span() {
+    let markdown = htmd::convert("<code>code`</code>").unwrap();
+
+    assert_eq!("`` code` ``", markdown);
+}
+
+#[test]
+fn fenced_code_uses_a_fence_longer_than_any_run_in_its_content() {
+    let markdown =
+        htmd::convert("<pre><code>`````\nlet parsed = true;\n`````</code></pre>").unwrap();
+
+    assert_eq!("``````\n`````\nlet parsed = true;\n`````\n``````", markdown);
+}
+
+#[test]
+fn tilde_fenced_code_uses_a_fence_longer_than_any_run_in_its_content() {
+    let converter = HtmlToMarkdown::builder()
+        .options(Options {
+            code_block_fence: CodeBlockFence::Tildes,
+            ..Default::default()
+        })
+        .build();
+
+    let markdown = converter
+        .convert("<pre><code>~~~~~\nlet parsed = true;\n~~~~~</code></pre>")
+        .unwrap();
+
+    assert_eq!("~~~~~~\n~~~~~\nlet parsed = true;\n~~~~~\n~~~~~~", markdown);
+}

--- a/tests/code_tests.rs
+++ b/tests/code_tests.rs
@@ -19,6 +19,20 @@ fn inline_code_ending_in_a_backtick_keeps_the_backtick_inside_the_span() {
 }
 
 #[test]
+fn preformatted_inline_code_preserves_boundary_spaces() {
+    let converter = HtmlToMarkdown::builder()
+        .options(Options {
+            preformatted_code: true,
+            ..Default::default()
+        })
+        .build();
+
+    let markdown = converter.convert("<code> foo </code>").unwrap();
+
+    assert_eq!("`  foo  `", markdown);
+}
+
+#[test]
 fn fenced_code_uses_a_fence_longer_than_any_run_in_its_content() {
     let markdown =
         htmd::convert("<pre><code>`````\nlet parsed = true;\n`````</code></pre>").unwrap();

--- a/tests/code_tests.rs
+++ b/tests/code_tests.rs
@@ -1,8 +1,124 @@
+use std::rc::Rc;
+
 use htmd::{
-    HtmlToMarkdown,
+    Element, HtmlToMarkdown, Node,
+    element_handler::Handlers,
     options::{CodeBlockFence, Options},
 };
+use indoc::indoc;
+use markup5ever_rcdom::NodeData;
 use pretty_assertions::assert_eq;
+
+mod common;
+use common::convert;
+
+fn find_element(node: &Rc<Node>, tag: &str) -> Option<Rc<Node>> {
+    if let NodeData::Element { name, .. } = &node.data
+        && name.local.as_ref() == tag
+    {
+        return Some(node.clone());
+    }
+
+    node.children
+        .borrow()
+        .iter()
+        .find_map(|child| find_element(child, tag))
+}
+
+#[test]
+fn code_blocks() {
+    let html = r#"
+        <pre><code>println!("Hello");</code></pre>
+        "#;
+    assert_eq!("```\nprintln!(\"Hello\");\n```", convert(html).unwrap());
+}
+
+#[test]
+fn code_blocks_with_lang_class() {
+    let html = r#"
+        <pre><code class="language-rust">println!("Hello");</code></pre>
+        "#;
+    assert_eq!("```rust\nprintln!(\"Hello\");\n```", convert(html).unwrap());
+}
+
+#[test]
+fn code_blocks_decode_html_entities() {
+    let html = r#"<pre><code>let x = 5 &amp;&amp; y &lt; 10;</code></pre>"#;
+
+    assert_eq!("```\nlet x = 5 && y < 10;\n```", convert(html).unwrap());
+}
+
+// See https://github.com/letmutex/htmd/issues/14 for background on this test --
+// the `class` attribute is deliberately misplaced to support Markdown renderers
+// which don't follow the CommonMark spec.
+#[test]
+fn code_blocks_with_lang_class_on_pre_tag() {
+    let html = r#"
+        <pre class="language-rust"><code>println!("Hello");</code></pre>
+        "#;
+    assert_eq!(
+        "```rust\nprintln!(\"Hello\");\n```",
+        htmd::convert(html).unwrap()
+    );
+}
+
+#[test]
+fn span_subtree_conversion_preserves_ancestor_preformatted_context() {
+    let converter = HtmlToMarkdown::new();
+    let tree = converter
+        .html_to_tree("<pre><span>  *literal*  \nsecond</span></pre>")
+        .unwrap();
+    let span = find_element(&tree, "span").unwrap();
+
+    assert_eq!("  *literal*  \nsecond", converter.tree_to_markdown(&span));
+}
+
+#[test]
+fn delegated_unhandled_subtree_preserves_ancestor_preformatted_context() {
+    let converter = HtmlToMarkdown::builder()
+        .add_handler(
+            vec!["delegate"],
+            |handlers: &dyn Handlers, element: Element| {
+                let child = element.node.children.borrow().first()?.clone();
+                handlers.handle(&child)
+            },
+        )
+        .build();
+
+    assert_eq!(
+        "  *literal*  \nsecond",
+        converter
+            .convert("<pre><delegate><mark>  *literal*  \nsecond</mark></delegate></pre>")
+            .unwrap()
+    );
+}
+
+#[test]
+fn faithful_mode_pre() {
+    assert_eq!(
+        convert(indoc!(r#"<pre>Test</pre>"#)).unwrap(),
+        indoc!(r#"<pre>Test</pre>"#)
+    );
+}
+
+#[test]
+fn faithful_mode_code_block1() {
+    assert_eq!(
+        convert(indoc!(r#"<pre><code accesskey="f">Test</code></pre>"#)).unwrap(),
+        indoc!(r#"<pre><code accesskey="f">Test</code></pre>"#)
+    );
+}
+
+#[test]
+fn faithful_mode_code_block2() {
+    assert_eq!(
+        convert(indoc!(
+            r#"<pre><code class="language-ruby"><i>Test</i></code></pre>"#
+        ))
+        .unwrap(),
+        indoc!(r#"<pre><code class="language-ruby"><i>Test</i></code></pre>"#)
+    );
+}
 
 #[test]
 fn inline_code_made_only_of_backticks_uses_a_non_colliding_delimiter() {

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -56,6 +56,54 @@ mod table_tests_1 {
     }
 
     #[test]
+    fn table_rows_do_not_drop_cells_beyond_the_header_width() {
+        let markdown = htmd::convert(
+            r#"
+            <table>
+                <thead>
+                    <tr><th>First</th><th>Second</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Alpha</td><td>Beta</td><td>Must survive</td></tr>
+                </tbody>
+            </table>
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            indoc!(
+                r#"
+                | First | Second |              |
+                | ----- | ------ | ------------ |
+                | Alpha | Beta   | Must survive |
+                "#
+            )
+            .trim(),
+            markdown
+        );
+    }
+
+    #[test]
+    fn malformed_table_foster_parenting_does_not_lose_visible_text() {
+        let markdown =
+            htmd::convert("<table>before<tr><th>heading</th></tr>after</table>").unwrap();
+
+        assert_eq!(
+            indoc!(
+                r#"
+                beforeafter
+
+                | heading |
+                | ------- |
+                "#
+            )
+            .trim(),
+            markdown
+        );
+    }
+
+    #[test]
     fn test_table_with_thead_tbody() {
         let html = r#"
         <table>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fenced code block rendering by selecting fence lengths based on the longest run inside the content.
  * Enhanced inline code formatting to better avoid delimiter collisions and preserve boundary spacing for preformatted inline code.
  * Corrected image destination formatting when the URL contains spaces, ensuring the title appears after the closing delimiter.
  * Preserved additional table cells when body rows exceed header width and improved output for malformed table markup.
  * Ensured misnested inline emphasis/text isn’t duplicated or lost.

* **Tests**
  * Added regression coverage for code rendering, image titles with spaced URLs, inline formatting edge cases, and table conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->