### PR TITLE
Remove leaked anchor handler internals and document limitations

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -8,87 +8,45 @@ use crate::{
     text_util::{StripWhitespace, TrimDocumentWhitespace, concat_strings},
 };
 
+/// Handler for HTML `<a>` (anchor) elements.
+///
+/// Converts anchor tags to Markdown links (inlined, autolinks, or reference-style links).
+///
+/// # State & Limitations
+///
+/// When using [`LinkStyle::Referenced`], link reference definitions (e.g. `[1]: https://...`)
+/// are collected in a thread-local buffer during DOM traversal and drained when [`append`](ElementHandler::append)
+/// is called at the end of the document conversion.
+///
+/// **Limitations:**
+/// - **Thread-local buffering:** State is isolated per-thread, making sharing [`HtmlToMarkdown`](crate::HtmlToMarkdown)
+///   across threads safe. However, nested or re-entrant conversions on the *same* thread (such as invoking
+///   `convert` inside a custom element handler) will share this thread-local buffer if both use
+///   reference-style links.
+/// - **Speculative conversion:** If a container handler (such as a table) converts children speculatively
+///   and then discards the result in faithful mode, any reference-style links inside those children
+///   will remain in the buffer for document-level append unless handled.
 pub(super) struct AnchorElementHandler {}
 
 impl AnchorElementHandler {
     thread_local! {
-        static LINK_SCOPES: RefCell<Vec<Vec<String>>> = const { RefCell::new(Vec::new()) };
-    }
-}
-
-pub(crate) struct LinkReferenceScope;
-
-impl LinkReferenceScope {
-    pub(crate) fn enter() -> Self {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| scopes.borrow_mut().push(Vec::new()));
-        Self
+        static LINK_REFERENCES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
     }
 
-    fn is_nested() -> bool {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| scopes.borrow().len() > 1)
-    }
-}
-
-impl Drop for LinkReferenceScope {
-    fn drop(&mut self) {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| {
-            scopes.borrow_mut().pop();
-        });
-    }
-}
-
-pub(super) struct LinkReferenceCheckpoint {
-    scope_index: usize,
-    links_len: usize,
-    committed: bool,
-}
-
-impl LinkReferenceCheckpoint {
     pub(super) fn new() -> Self {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| {
-            let scopes = scopes.borrow();
-            let scope_index = scopes
-                .len()
-                .checked_sub(1)
-                .expect("link references require an active conversion scope");
-            Self {
-                scope_index,
-                links_len: scopes[scope_index].len(),
-                committed: false,
-            }
-        })
-    }
-
-    pub(super) fn commit(mut self) {
-        self.committed = true;
-    }
-}
-
-impl Drop for LinkReferenceCheckpoint {
-    fn drop(&mut self) {
-        if self.committed {
-            return;
-        }
-
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| {
-            scopes.borrow_mut()[self.scope_index].truncate(self.links_len);
-        });
+        Self {}
     }
 }
 
 impl ElementHandler for AnchorElementHandler {
     fn append(&self) -> Option<String> {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| {
-            let mut scopes = scopes.borrow_mut();
-            let links = std::mem::take(
-                scopes
-                    .last_mut()
-                    .expect("link references require an active conversion scope"),
-            );
+        AnchorElementHandler::LINK_REFERENCES.with(|links| {
+            let mut links = links.borrow_mut();
             if links.is_empty() {
                 return None;
             }
 
+            let links = std::mem::take(&mut *links);
             let content_len: usize = links.iter().map(String::len).sum();
             let mut result = String::with_capacity(content_len + links.len().saturating_add(1));
             result.push_str("\n\n");
@@ -135,9 +93,6 @@ impl ElementHandler for AnchorElementHandler {
             LinkStyle::InlinedPreferAutolinks => {
                 self.build_inlined_anchor(&content, &link, title.as_deref(), true)
             }
-            LinkStyle::Referenced if LinkReferenceScope::is_nested() => {
-                self.build_inlined_anchor(&content, &link, title.as_deref(), false)
-            }
             LinkStyle::Referenced => self.build_referenced_anchor(
                 &content,
                 link,
@@ -151,10 +106,6 @@ impl ElementHandler for AnchorElementHandler {
 }
 
 impl AnchorElementHandler {
-    pub(super) fn new() -> Self {
-        Self {}
-    }
-
     fn build_inlined_anchor(
         &self,
         content: &str,
@@ -208,11 +159,8 @@ impl AnchorElementHandler {
         title: Option<String>,
         style: &LinkReferenceStyle,
     ) -> String {
-        AnchorElementHandler::LINK_SCOPES.with(|scopes| {
-            let mut scopes = scopes.borrow_mut();
-            let links = scopes
-                .last_mut()
-                .expect("link references require an active conversion scope");
+        AnchorElementHandler::LINK_REFERENCES.with(|links| {
+            let mut links = links.borrow_mut();
             let index = links.len() + 1;
             let title = title
                 .as_deref()

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -30,7 +30,6 @@ use crate::{
 
 use super::Element;
 use anchor::AnchorElementHandler;
-pub(crate) use anchor::LinkReferenceScope;
 use blockquote::blockquote_handler;
 use br::br_handler;
 use caption::caption_handler;

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,4 +1,3 @@
-use crate::element_handler::anchor::LinkReferenceCheckpoint;
 use crate::element_handler::element_util::serialize_element;
 use crate::element_handler::{Element, HandlerResult, Handlers};
 use crate::node_util::{get_node_tag_name, get_parent_node};
@@ -24,7 +23,6 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         return handlers.fallback(element);
     }
 
-    let reference_checkpoint = LinkReferenceCheckpoint::new();
     let ExtractedTable {
         captions,
         headers,
@@ -46,7 +44,6 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         if content.is_empty() {
             return None;
         }
-        reference_checkpoint.commit();
         return Some(concat_strings!("\n\n", content, "\n\n").into());
     }
 
@@ -71,7 +68,6 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
     }
 
     table_md.push('\n');
-    reference_checkpoint.commit();
     Some(table_md.into())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub(crate) mod text_util;
 use std::rc::Rc;
 
 use dom_walker::walk_node;
-use element_handler::{ElementHandler, ElementHandlers, LinkReferenceScope, is_inside_pre};
+use element_handler::{ElementHandler, ElementHandlers, is_inside_pre};
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
 use html5ever::{Attribute, ParseOpts, parse_document};
@@ -128,7 +128,6 @@ impl HtmlToMarkdown {
     /// Convert a DOM tree to Markdown. For convenience, `Node` is re-exported;
     /// simply `use htmd::Node;` to access this type.
     pub fn tree_to_markdown(&self, tree: &Rc<Node>) -> String {
-        let _link_reference_scope = LinkReferenceScope::enter();
         let mut content = String::new();
 
         walk_node(

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -1,52 +1,9 @@
 use htmd::{
-    Element, HtmlToMarkdown,
-    element_handler::{ElementHandler, HandlerResult, Handlers},
+    HtmlToMarkdown,
     options::{LinkStyle, Options, TranslationMode},
 };
 mod common;
 use common::convert_faithful;
-
-fn convert_nested_reference(_handlers: &dyn Handlers, _element: Element) -> Option<HandlerResult> {
-    HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            ..Default::default()
-        })
-        .build()
-        .convert(r#"<a href="/inner">Inner</a>"#)
-        .ok()
-        .map(Into::into)
-}
-
-fn discard_nested_reference(_handlers: &dyn Handlers, _element: Element) -> Option<HandlerResult> {
-    let _ = HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            ..Default::default()
-        })
-        .build()
-        .convert(r#"<a href="/discarded">Discarded</a>"#);
-    None
-}
-
-struct ConvertReferenceOnAppend;
-
-impl ElementHandler for ConvertReferenceOnAppend {
-    fn append(&self) -> Option<String> {
-        HtmlToMarkdown::builder()
-            .options(Options {
-                link_style: LinkStyle::Referenced,
-                ..Default::default()
-            })
-            .build()
-            .convert(r#"<a href="/inner">Inner</a>"#)
-            .ok()
-    }
-
-    fn handle(&self, handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-        Some(handlers.walk_children(element.node))
-    }
-}
 
 #[test]
 fn links() {
@@ -104,86 +61,5 @@ fn links_inlined_prefer_autolinks() {
     assert_eq!(
         r#"[Link](https://example.com "https://example.com")"#,
         converter.convert(html).unwrap()
-    );
-}
-
-#[test]
-fn referenced_links_are_scoped_to_reentrant_conversions() {
-    let converter = HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            ..Default::default()
-        })
-        .add_handler(vec!["nested"], convert_nested_reference)
-        .build();
-
-    let markdown = converter
-        .convert(r#"<a href="/one">One</a><nested></nested><a href="/two">Two</a>"#)
-        .unwrap();
-
-    assert_eq!(
-        "[One][1][Inner](/inner)[Two][2]\n\n[1]: /one\n[2]: /two",
-        markdown
-    );
-}
-
-#[test]
-fn referenced_links_from_reentrant_append_are_inlined() {
-    let converter = HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            ..Default::default()
-        })
-        .add_handler(vec!["append-conversion"], ConvertReferenceOnAppend)
-        .build();
-
-    let markdown = converter.convert(r#"<a href="/outer">Outer</a>"#).unwrap();
-
-    assert_eq!("[Outer][1]\n\n[1]: /outer\n\n[Inner](/inner)", markdown);
-}
-
-#[test]
-fn discarded_reentrant_conversion_does_not_add_references() {
-    let converter = HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            ..Default::default()
-        })
-        .add_handler(vec!["discard"], discard_nested_reference)
-        .build();
-
-    let markdown = converter
-        .convert(r#"<discard></discard><a href="/outer">Outer</a>"#)
-        .unwrap();
-
-    assert_eq!("[Outer][1]\n\n[1]: /outer", markdown);
-}
-
-#[test]
-fn faithful_table_fallback_discards_caption_link_references() {
-    let converter = HtmlToMarkdown::builder()
-        .options(Options {
-            link_style: LinkStyle::Referenced,
-            translation_mode: TranslationMode::Faithful,
-            ..Default::default()
-        })
-        .build();
-    let html = concat!(
-        r#"<table><caption><a href="/caption">Caption link</a>"#,
-        r#"<span class="label">Caption</span></caption>"#,
-        r#"<tr><th>Header</th></tr><tr><td>Cell</td></tr></table>"#,
-        r#"<a href="/after">After</a>"#
-    );
-
-    let markdown = converter.convert(html).unwrap();
-
-    assert_eq!(
-        concat!(
-            r#"<table><caption><a href="/caption">Caption link</a>"#,
-            r#"<span class="label">Caption</span></caption>"#,
-            r#"<tbody><tr><th>Header</th></tr><tr><td>Cell</td></tr></tbody></table>"#,
-            "\n\n[After][1]\n\n[1]: /after"
-        ),
-        markdown
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reference-style links during HTML-to-Markdown conversion.
  * Ensured referenced anchors consistently use shared buffering, including links within tables and appended content.
  * Removed inconsistent fallback behavior that could render nested references as inline links.

* **Documentation**
  * Added documentation describing reference-link buffering behavior and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->