### PR TITLE
Parse turndown case options instead of matching option strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ indoc = "2.0.6"
 scraper = "0.27"
 criterion = { version = "0.8", features = ["html_reports"] }
 pretty_assertions = "1.4.1"
-# Parses the `data-options` of a turndown case, so that a key the runner does not
-# know is a test failure rather than a silent fall back to the defaults.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ indoc = "2.0.6"
 scraper = "0.27"
 criterion = { version = "0.8", features = ["html_reports"] }
 pretty_assertions = "1.4.1"
+# Parses the `data-options` of a turndown case, so that a key the runner does not
+# know is a test failure rather than a silent fall back to the defaults.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [[bench]]
 name = "convert_bench"

--- a/tests/html/turndown_test_index.html
+++ b/tests/html/turndown_test_index.html
@@ -668,17 +668,7 @@ Another paragraph.
 Another div</pre>
 </div>
 
-<div class="case" data-name="multiple divs" data-options='{"translationMode": "Pure"}>
-  <div class="input">
-    <div>A div</div>
-    <div>Another div</div>
-  </div>
-  <pre class="expected">A div
-
-Another div</pre>
-</div>
-
-<div class="case" data-name="comment" data-options='{"translationMode": "Pure"}>
+<div class="case" data-name="comment" data-options='{"translationMode": "Pure"}'>
   <div class="input"><!-- comment --></div>
   <pre class="expected"></pre>
 </div>

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -7,7 +7,7 @@ use htmd::{
 };
 use pretty_assertions::assert_eq;
 use scraper::{Html, Selector};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 struct TestCase {
     pub name: String,
@@ -25,16 +25,38 @@ struct TestCase {
 #[derive(Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct CaseOptions {
+    #[serde(default, deserialize_with = "present_value")]
     heading_style: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     hr: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     br: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     link_style: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     link_reference_style: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     code_block_style: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     fence: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     bullet_list_marker: Option<String>,
+    #[serde(default, deserialize_with = "present_value")]
     preformatted_code: Option<bool>,
+    #[serde(default, deserialize_with = "present_value")]
     translation_mode: Option<String>,
+}
+
+/// Reads a key that is present, rejecting an explicit `null`.
+///
+/// An absent key still becomes `None` through `#[serde(default)]`. Without this,
+/// so would `null`: another way to name an option and still get the default.
+fn present_value<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Some)
 }
 
 #[test]

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -163,8 +163,6 @@ fn run_cases() {
     }
 }
 
-/// A key the runner knows, carrying a value it does not. Like an unknown key,
-/// this used to fall back to the default and test the wrong thing quietly.
 fn unsupported(case: &str, key: &str, value: &str) -> ! {
     panic!("case {case:?}: unsupported value {value:?} for `{key}`");
 }

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -7,93 +7,104 @@ use htmd::{
 };
 use pretty_assertions::assert_eq;
 use scraper::{Html, Selector};
+use serde::Deserialize;
 
 struct TestCase {
     pub name: String,
     pub html: String,
     pub md: String,
-    pub data_options: Option<String>,
+    pub options: CaseOptions,
+}
+
+/// The `data-options` of a case, named as turndown names them.
+///
+/// Every key is optional and every unknown one is an error: a misspelling used
+/// to leave the case running under the defaults, passing while testing something
+/// other than what it says. A malformed attribute did worse — html5ever swallows
+/// markup into an unterminated one, silently costing the file a whole case.
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct CaseOptions {
+    heading_style: Option<String>,
+    hr: Option<String>,
+    br: Option<String>,
+    link_style: Option<String>,
+    link_reference_style: Option<String>,
+    code_block_style: Option<String>,
+    fence: Option<String>,
+    bullet_list_marker: Option<String>,
+    preformatted_code: Option<bool>,
+    translation_mode: Option<String>,
 }
 
 #[test]
 fn run_cases() {
     let cases = load_test_cases();
     for (index, case) in cases.iter().enumerate() {
-        let opt = case.data_options.as_ref();
+        let opt = &case.options;
+        let name = case.name.as_str();
 
-        let is_atx_heading = opt.is_some_and(|opt| opt == r#"{"headingStyle":"atx"}"#);
-        let heading_style = if is_atx_heading {
-            HeadingStyle::Atx
-        } else {
-            HeadingStyle::Setex
+        let heading_style = match opt.heading_style.as_deref() {
+            Some("atx") => HeadingStyle::Atx,
+            Some("setext") | None => HeadingStyle::Setex,
+            Some(value) => unsupported(name, "headingStyle", value),
         };
 
-        let is_dashes_hr = opt.is_some_and(|opt| opt == r#"{"hr": "- - -"}"#);
-        let hr_style = if is_dashes_hr {
-            HrStyle::Dashes
-        } else {
-            HrStyle::Asterisks
+        let hr_style = match opt.hr.as_deref() {
+            Some("- - -") => HrStyle::Dashes,
+            Some("* * *") | None => HrStyle::Asterisks,
+            Some(value) => unsupported(name, "hr", value),
         };
 
-        let is_referenced_link =
-            opt.is_some_and(|opt| opt.starts_with(r#"{"linkStyle": "referenced""#));
-        let link_style = if is_referenced_link {
-            LinkStyle::Referenced
-        } else {
-            LinkStyle::Inlined
+        let link_style = match opt.link_style.as_deref() {
+            Some("referenced") => LinkStyle::Referenced,
+            Some("inlined") | None => LinkStyle::Inlined,
+            Some(value) => unsupported(name, "linkStyle", value),
         };
 
-        let link_reference_style = match opt.map(|opt| opt.as_str()) {
-            Some(r#"{"linkStyle": "referenced", "linkReferenceStyle": "collapsed"}"#) => {
-                LinkReferenceStyle::Collapsed
-            }
-            Some(r#"{"linkStyle": "referenced", "linkReferenceStyle": "shortcut"}"#) => {
-                LinkReferenceStyle::Shortcut
-            }
-            _ => LinkReferenceStyle::Full,
+        let link_reference_style = match opt.link_reference_style.as_deref() {
+            Some("collapsed") => LinkReferenceStyle::Collapsed,
+            Some("shortcut") => LinkReferenceStyle::Shortcut,
+            Some("full") | None => LinkReferenceStyle::Full,
+            Some(value) => unsupported(name, "linkReferenceStyle", value),
         };
 
-        let is_backslash_br = opt.is_some_and(|opt| opt == r#"{"br": "\\"}"#);
-        let br_style = if is_backslash_br {
-            BrStyle::Backslash
-        } else {
-            BrStyle::TwoSpaces
+        // JSON decoding has already turned the attribute's `"\\"` into the one
+        // backslash it stands for.
+        let br_style = match opt.br.as_deref() {
+            Some("\\") => BrStyle::Backslash,
+            Some("  ") | None => BrStyle::TwoSpaces,
+            Some(value) => unsupported(name, "br", value),
         };
 
-        let is_fenced_code_block =
-            opt.is_some_and(|opt| opt.starts_with(r#"{"codeBlockStyle": "fenced""#));
-        let code_block_style = if is_fenced_code_block {
-            CodeBlockStyle::Fenced
-        } else {
-            CodeBlockStyle::Indented
+        let code_block_style = match opt.code_block_style.as_deref() {
+            Some("fenced") => CodeBlockStyle::Fenced,
+            Some("indented") | None => CodeBlockStyle::Indented,
+            Some(value) => unsupported(name, "codeBlockStyle", value),
         };
 
-        let is_tildes_fence = opt.is_some_and(|opt| opt.contains(r#""fence": "~~~""#));
-        let code_block_fence = if is_tildes_fence {
-            CodeBlockFence::Tildes
-        } else {
-            CodeBlockFence::Backticks
+        let code_block_fence = match opt.fence.as_deref() {
+            Some("~~~") => CodeBlockFence::Tildes,
+            Some("```") | None => CodeBlockFence::Backticks,
+            Some(value) => unsupported(name, "fence", value),
         };
 
-        let is_dash_bullet_list_marker =
-            opt.is_some_and(|opt| opt == r#"{"bulletListMarker": "-"}"#);
-        let bullet_list_marker = if is_dash_bullet_list_marker {
-            BulletListMarker::Dash
-        } else {
-            BulletListMarker::Asterisk
+        let bullet_list_marker = match opt.bullet_list_marker.as_deref() {
+            Some("-") => BulletListMarker::Dash,
+            Some("*") | None => BulletListMarker::Asterisk,
+            Some(value) => unsupported(name, "bulletListMarker", value),
         };
 
         let ul_bullet_spacing = 3;
         let ol_number_spacing = 2;
 
-        let preformatted_code = opt.is_some_and(|opt| opt == r#"{"preformattedCode": true}"#);
+        let preformatted_code = opt.preformatted_code.unwrap_or(false);
 
-        let translation_mode =
-            if opt.is_some_and(|opt| opt.contains(r#""translationMode": "Pure""#)) {
-                TranslationMode::Pure
-            } else {
-                TranslationMode::Faithful
-            };
+        let translation_mode = match opt.translation_mode.as_deref() {
+            Some("Pure") => TranslationMode::Pure,
+            Some("Faithful") | None => TranslationMode::Faithful,
+            Some(value) => unsupported(name, "translationMode", value),
+        };
 
         let converter = HtmlToMarkdown::builder()
             .options(Options {
@@ -130,6 +141,12 @@ fn run_cases() {
     }
 }
 
+/// A key the runner knows, carrying a value it does not. Like an unknown key,
+/// this used to fall back to the default and test the wrong thing quietly.
+fn unsupported(case: &str, key: &str, value: &str) -> ! {
+    panic!("case {case:?}: unsupported value {value:?} for `{key}`");
+}
+
 fn load_test_cases() -> Vec<TestCase> {
     let mut cases = Vec::<TestCase>::new();
 
@@ -151,14 +168,19 @@ fn load_test_cases() -> Vec<TestCase> {
             .next()
             .unwrap()
             .inner_html();
-        let data_options = case_element
+        let options = case_element
             .attr("data-options")
-            .map(|attr| attr.to_string());
+            .map(|attr| {
+                serde_json::from_str(attr).unwrap_or_else(|err| {
+                    panic!("case {name:?} has unreadable data-options {attr:?}: {err}")
+                })
+            })
+            .unwrap_or_default();
         cases.push(TestCase {
             name: name.to_string(),
             html: case_input,
             md: case_expected,
-            data_options,
+            options,
         })
     }
 


### PR DESCRIPTION
This is a nice fix that came from some of the churn in #78. Written by Claude.

The turndown runner compared the raw `data-options` attribute against exact strings, so a misspelled key or an unhandled value silently fell back to the defaults and the case passed while testing something else. Decode the attribute into a struct with `deny_unknown_fields` and panic on any value the runner cannot map.

This surfaced an unterminated attribute quote on a duplicate "multiple divs" case: html5ever swallowed markup up to the next quote, absorbing the "comment" case so it ran under the wrong name. Drop the duplicate and close the quote on "comment".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that HTML comments produce empty output in Pure translation mode.
  * Improved test-case option validation so unsupported or malformed settings are reported as failures instead of silently using defaults.
  * Updated test parsing to apply explicit defaults consistently, improving confidence in conversion behavior.

* **Chores**
  * Added development tooling required for structured test-option validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->