### PR TITLE
Add: In faithful mode, write `<br>` as the tag itself.

### DIFF
--- a/src/element_handler/br.rs
+++ b/src/element_handler/br.rs
@@ -1,12 +1,21 @@
 use crate::{
     Element,
     element_handler::{HandlerResult, Handlers},
-    options::BrStyle,
+    options::{BrStyle, TranslationMode},
     serialize_if_faithful,
 };
 
 pub(super) fn br_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_faithful!(
+        handlers,
+        element,
+        // In faithful mode, only emit `<br>`, not one of the problematic CommonMark encodings.
+        if handlers.options().translation_mode == TranslationMode::Faithful {
+            -1
+        } else {
+            0
+        }
+    );
 
     match handlers.options().br_style {
         BrStyle::TwoSpaces => Some("  \n".into()),

--- a/src/options.rs
+++ b/src/options.rs
@@ -53,7 +53,7 @@ pub enum HrStyle {
     Underscores,
 }
 
-/// When in `TranslationMode::Faithlful`, this is ignored; in this mode,
+/// When in `TranslationMode::Faithful`, this is ignored; in this mode,
 /// `<br>` is always translated as `<br>`.
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum BrStyle {

--- a/src/options.rs
+++ b/src/options.rs
@@ -53,6 +53,8 @@ pub enum HrStyle {
     Underscores,
 }
 
+/// When in `TranslationMode::Faithlful`, this is ignored; in this mode,
+/// `<br>` is always translated as `<br>`.
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum BrStyle {
     TwoSpaces,

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use htmd::{
     Element, HtmlToMarkdown,
     element_handler::Handlers,
-    options::{BrStyle, LinkStyle, Options, TranslationMode},
+    options::{LinkStyle, Options, TranslationMode},
 };
 mod common;
 use common::convert_faithful;
@@ -146,19 +146,8 @@ fn quotes() {
 #[test]
 fn br() {
     let html = r#"
-        Hi<br>there<br><br>!"#;
-    assert_eq!("Hi  \nthere  \n  \n!", convert_faithful(html).unwrap());
-
-    let md = HtmlToMarkdown::builder()
-        .options(Options {
-            br_style: BrStyle::Backslash,
-            translation_mode: TranslationMode::Faithful,
-            ..Default::default()
-        })
-        .build()
-        .convert(html)
-        .unwrap();
-    assert_eq!("Hi\\\nthere\\\n\\\n!", &md);
+        <p>Hi<br>there<br><br>!</p>"#;
+    assert_eq!("Hi<br>there<br><br>!", convert_faithful(html).unwrap());
 }
 
 #[test]

--- a/tests/html/turndown_test_index.html
+++ b/tests/html/turndown_test_index.html
@@ -146,13 +146,13 @@ sit</pre>
   <pre class="expected">- - -</pre>
 </div>
 
-<div class="case" data-name="br">
+<div class="case" data-name="br" data-options='{"translationMode": "Pure"}'>
   <div class="input">More<br>after the break</div>
   <pre class="expected">More  
 after the break</pre>
 </div>
 
-<div class="case" data-name="br with visible line-ending" data-options='{"br": "\\"}'>
+<div class="case" data-name="br with visible line-ending" data-options='{"br": "\\", "translationMode": "Pure"}'>
   <div class="input">More<br>after the break</div>
   <pre class="expected">More\
 after the break</pre>
@@ -741,7 +741,7 @@ Another div</pre>
 </div>
 
 <!-- Two trailing newlines are for the line break -->
-<div class="case" data-name="newline at the end of a strong element">
+<div class="case" data-name="newline at the end of a strong element" data-options='{"translationMode": "Pure"}'>
     <div class="input"><strong>Text with a trailing break<br></strong>before continuation</div>
     <pre class="expected">**Text with a trailing break**  
 before continuation</pre>
@@ -768,7 +768,7 @@ before continuation</pre>
 text after blank div</pre>
 </div>
 
-<div class="case" data-name="blank inline element with br">
+<div class="case" data-name="blank inline element with br" data-options='{"translationMode": "Pure"}'>
   <div class="input"><strong><br></strong></div>
   <pre class="expected"></pre>
 </div>
@@ -1060,7 +1060,7 @@ Code
   <pre class="expected">Foo &nbsp; Bar</pre>
 </div>
 
-<div class="case" data-name="list-like text with non-breaking spaces">
+<div class="case" data-name="list-like text with non-breaking spaces" data-options='{"translationMode": "Pure"}'>
   <div class="input">&nbsp;1. First<br>&nbsp;2. Second</div>
   <pre class="expected">&nbsp;1. First  <!-- hard break -->
 &nbsp;2. Second</pre>


### PR DESCRIPTION
This avoid a number of special cases that CommonMark's encoding of `<br>` as either `\` followed by a newline or two spaces followed by a newline produces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In Faithful translation mode, HTML `<br>` elements are now preserved as `<br>` instead of being converted into Markdown hard line breaks.
  * Pure translation mode continues to apply the existing `<br>` conversion behavior.
  * This ensures faithful output retains the original HTML line-break elements consistently.

* **Documentation**
  * Clarified that the line-break styling option is ignored in Faithful mode, where `<br>` elements are always preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->