### PR TITLE
Refactor: collect repeated block framing and HTML fallback into helpers.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -161,20 +161,39 @@ fn is_math_span(attrs: &[html5ever::Attribute]) -> bool {
         )
 }
 
+/// The bytes which, at the start of a text node, could open a CommonMark block
+/// — a setext underline, a code fence, a blockquote, a list marker, an ATX
+/// heading, or an ordered list number — and so need a leading backslash. Every
+/// one is ASCII, so testing the first byte of a text node tests its first
+/// character.
+fn is_markdown_block_start(byte: u8) -> bool {
+    matches!(byte, b'=' | b'~' | b'>' | b'-' | b'+' | b'#' | b'0'..=b'9')
+}
+
+/// The bytes which carry CommonMark meaning wherever in a text node they
+/// appear, and so are escaped one by one.
+fn is_markdown_inline_special(byte: u8) -> bool {
+    matches!(byte, b'\\' | b'*' | b'_' | b'`' | b'[' | b']')
+}
+
 fn is_plain_text(text: &str) -> bool {
     let bytes = text.as_bytes();
     let Some(&first) = bytes.first() else {
         return true;
     };
 
-    if matches!(first, b'=' | b'~' | b'>' | b'-' | b'+' | b'#' | b'0'..=b'9') {
+    if is_markdown_block_start(first) {
         return false;
     }
 
     let mut previous_was_space = false;
     for &byte in bytes {
+        // `<` opens HTML rather than Markdown, so `escape_if_needed` leaves it
+        // to the HTML escape rather than listing it as a special of its own.
+        if is_markdown_inline_special(byte) || byte == b'<' {
+            return false;
+        }
         match byte {
-            b'\\' | b'*' | b'_' | b'`' | b'[' | b']' | b'<' => return false,
             b' ' => {
                 if previous_was_space {
                     return false;
@@ -397,13 +416,11 @@ fn escape_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
         return text;
     };
 
-    let mut need_escape = matches!(first, '=' | '~' | '>' | '-' | '+' | '#' | '0'..='9');
+    let mut need_escape = is_markdown_block_start(text.as_bytes()[0]);
 
     if !need_escape {
         // Markdown specials are all ASCII; byte scan avoids UTF-8 decoding.
-        need_escape = text
-            .bytes()
-            .any(|b| matches!(b, b'\\' | b'*' | b'_' | b'`' | b'[' | b']'));
+        need_escape = text.bytes().any(is_markdown_inline_special);
     }
 
     if !need_escape {

--- a/src/element_handler/blockquote.rs
+++ b/src/element_handler/blockquote.rs
@@ -2,7 +2,7 @@ use crate::{
     Element,
     element_handler::{HandlerResult, Handlers},
     serialize_if_faithful,
-    text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings},
+    text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings, frame_as_block},
 };
 
 pub(super) fn blockquote_handler(
@@ -17,5 +17,5 @@ pub(super) fn blockquote_handler(
         .lines()
         .map(|line| concat_strings!("> ", line))
         .join("\n");
-    Some(concat_strings!("\n\n", content, "\n\n").into())
+    Some(frame_as_block(&content).into())
 }

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -5,7 +5,7 @@ use markup5ever_rcdom::{Node, NodeData};
 
 use crate::{
     Element,
-    element_handler::{HandlerResult, Handlers, serialize_element},
+    element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::{get_node_tag_name, get_parent_node},
     options::{CodeBlockFence, CodeBlockStyle, TranslationMode},
     serialize_if_faithful,
@@ -23,10 +23,7 @@ pub(super) fn code_handler(handlers: &dyn Handlers, element: Element) -> Option<
             .iter()
             .all(|node| matches!(node.data, NodeData::Text { .. }))
     {
-        return Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        });
+        return Some(serialize_element_result(handlers, &element));
     }
 
     // Determine the type: inline code or a code block.

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -4,7 +4,7 @@ use crate::{
     element_handler::{HandlerResult, Handlers},
     node_util::parent_tag_name_equals,
     options::TranslationMode,
-    text_util::concat_strings,
+    text_util::frame_as_block,
 };
 use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer, TraversalScope, serialize};
 use markup5ever_rcdom::{NodeData, SerializableHandle};
@@ -26,18 +26,24 @@ pub(super) fn handle_or_serialize_by_parent(
     if handlers.options().translation_mode == TranslationMode::Faithful
         && !parent_tag_name_equals(element.node, tag_names)
     {
-        Some(HandlerResult {
-            content: serialize_element(handlers, element),
-            markdown_translated: false,
-        })
+        Some(serialize_element_result(handlers, element))
     } else {
         let result = handlers.walk_children(element.node);
-        let content = result.content.trim_matches('\n');
         Some(HandlerResult {
-            content: concat_strings!("\n\n", content, "\n\n"),
+            content: frame_as_block(&result.content),
             markdown_translated: !propagate_children_translation || result.markdown_translated,
         })
     }
+}
+
+/// The [`HandlerResult`] for an element which can only be written as HTML: the
+/// element serialized, reported as not translated so that a container needing
+/// all-CommonMark children can serialize itself instead.
+pub(crate) fn serialize_element_result(
+    handlers: &dyn Handlers,
+    element: &Element,
+) -> HandlerResult {
+    HandlerResult::html(serialize_element(handlers, element))
 }
 
 pub(crate) fn serialize_element(handlers: &dyn Handlers, element: &Element) -> String {
@@ -87,11 +93,7 @@ fn serialize_block_element(element: &Element, options: SerializeOpts) -> io::Res
     let handle = SerializableHandle::from(element.node.clone());
     serialize(&mut bytes, &handle, options)?;
     let html = String::from_utf8(bytes).map_err(io::Error::other)?;
-    Ok(concat_strings!(
-        "\n\n",
-        escape_html_block_blank_lines(&html),
-        "\n\n"
-    ))
+    Ok(frame_as_block(&escape_html_block_blank_lines(&html)))
 }
 
 // A blank line terminates a CommonMark HTML block. Encode every line ending

--- a/src/element_handler/html.rs
+++ b/src/element_handler/html.rs
@@ -2,33 +2,23 @@ use markup5ever_rcdom::NodeData;
 
 use crate::{
     Element,
-    element_handler::{HandlerResult, Handlers, serialize_element},
+    element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::get_parent_node,
     options::TranslationMode,
-    text_util::concat_strings,
+    text_util::frame_as_block,
 };
 
 pub(super) fn html_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    // In faithful mode, this is markdown translatable only when it's the root
-    // of the document.
-    let markdown_translatable = if handlers.options().translation_mode == TranslationMode::Faithful
-        && let Some(parent) = get_parent_node(element.node)
-        && let NodeData::Document = parent.data
-    {
-        true
-    } else {
-        // It's always markdown translatable in pure mode.
-        handlers.options().translation_mode == TranslationMode::Pure
-    };
+    // It's always markdown translatable in pure mode; in faithful mode, only
+    // when it's the root of the document.
+    let markdown_translatable = handlers.options().translation_mode == TranslationMode::Pure
+        || get_parent_node(element.node)
+            .is_some_and(|parent| matches!(parent.data, NodeData::Document));
 
     if markdown_translatable {
         let content = handlers.walk_children(element.node).content;
-        let content = content.trim_matches('\n');
-        Some(concat_strings!("\n\n", content, "\n\n").into())
+        Some(frame_as_block(&content).into())
     } else {
-        Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        })
+        Some(serialize_element_result(handlers, &element))
     }
 }

--- a/src/element_handler/list.rs
+++ b/src/element_handler/list.rs
@@ -2,11 +2,11 @@ use markup5ever_rcdom::NodeData;
 
 use crate::{
     Element,
-    element_handler::{HandlerResult, Handlers, serialize_element},
+    element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::{get_node_tag_name, get_parent_node},
     options::{Options, TranslationMode},
     serialize_if_faithful,
-    text_util::{append_block, concat_strings, indent_text_except_first_line},
+    text_util::{append_block, concat_strings, frame_as_block, indent_text_except_first_line},
 };
 
 pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
@@ -29,10 +29,7 @@ pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<
                 tag_name == Some("li") || tag_name.is_none()
             })
         {
-            return Some(HandlerResult {
-                content: serialize_element(handlers, &element),
-                markdown_translated: false,
-            });
+            return Some(serialize_element_result(handlers, &element));
         }
     }
     let parent = get_parent_node(element.node);
@@ -53,10 +50,7 @@ pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<
     if handlers.options().translation_mode == TranslationMode::Faithful
         && !result.markdown_translated
     {
-        return Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        });
+        return Some(serialize_element_result(handlers, &element));
     }
 
     let trimmed = result.content.trim_matches(|ch| ch == '\n');
@@ -67,7 +61,7 @@ pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<
     if is_parent_li {
         Some(concat_strings!("\n", trimmed, "\n").into())
     } else {
-        Some(concat_strings!("\n\n", trimmed, "\n\n").into())
+        Some(frame_as_block(trimmed).into())
     }
 }
 

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -3,7 +3,7 @@ mod blockquote;
 mod br;
 mod caption;
 mod code;
-mod element_util;
+pub(crate) mod element_util;
 mod emphasis;
 mod head_body;
 mod headings;
@@ -23,9 +23,9 @@ mod tr;
 
 use crate::{
     dom_walker::walk_node,
-    element_handler::element_util::serialize_element,
+    element_handler::element_util::serialize_element_result,
     options::{Options, TranslationMode},
-    text_util::concat_strings,
+    text_util::frame_as_block,
 };
 
 use super::Element;
@@ -76,6 +76,18 @@ impl From<&str> for HandlerResult {
         HandlerResult {
             content: value.to_string(),
             markdown_translated: true,
+        }
+    }
+}
+
+impl HandlerResult {
+    /// The result for an element written as HTML rather than translated. Its
+    /// `markdown_translated` is false, so a container which needs every child
+    /// in CommonMark can fall back to serializing itself.
+    pub(crate) fn html(content: String) -> Self {
+        HandlerResult {
+            content,
+            markdown_translated: false,
         }
     }
 }
@@ -215,32 +227,18 @@ impl ElementHandlers {
         markdown_translated: bool,
         skipped_handlers: usize,
     ) -> Option<HandlerResult> {
+        let element = Element {
+            node,
+            tag,
+            attrs,
+            markdown_translated,
+            skipped_handlers,
+        };
         match self.find_handler(tag, skipped_handlers) {
-            Some(handler) => handler.handle(
-                self,
-                Element {
-                    node,
-                    tag,
-                    attrs,
-                    markdown_translated,
-                    skipped_handlers,
-                },
-            ),
+            Some(handler) => handler.handle(self, element),
             None => {
                 if self.options.translation_mode == TranslationMode::Faithful {
-                    Some(HandlerResult {
-                        content: serialize_element(
-                            self,
-                            &Element {
-                                node,
-                                tag,
-                                attrs,
-                                markdown_translated,
-                                skipped_handlers: 0,
-                            },
-                        ),
-                        markdown_translated: false,
-                    })
+                    Some(serialize_element_result(self, &element))
                 } else {
                     // Default behavior: walk children and return their content
                     Some(self.walk_children(node))
@@ -298,7 +296,7 @@ impl Handlers for ElementHandlers {
         let mut output = String::new();
         let tag = crate::node_util::get_node_tag_name(node);
         let is_block = tag.is_some_and(crate::dom_walker::is_block_element);
-        let is_pre = tag.is_some_and(|t| t == "pre" || t == "code") || is_inside_pre(node);
+        let is_pre = tag.is_some_and(is_pre_element) || is_inside_pre(node);
         let markdown_translated =
             crate::dom_walker::walk_children(node, &mut output, self, is_block, is_pre);
         HandlerResult {
@@ -312,12 +310,15 @@ impl Handlers for ElementHandlers {
     }
 }
 
+/// Whether `tag` preserves whitespace and holds text which goes out unescaped.
+fn is_pre_element(tag: &str) -> bool {
+    tag == "pre" || tag == "code"
+}
+
 pub(crate) fn is_inside_pre(node: &Rc<Node>) -> bool {
     let mut current = crate::node_util::get_parent_node(node);
     while let Some(parent) = current {
-        if let Some(tag) = crate::node_util::get_node_tag_name(&parent)
-            && (tag == "pre" || tag == "code")
-        {
+        if crate::node_util::get_node_tag_name(&parent).is_some_and(is_pre_element) {
             return true;
         }
         current = crate::node_util::get_parent_node(&parent);
@@ -328,13 +329,9 @@ pub(crate) fn is_inside_pre(node: &Rc<Node>) -> bool {
 fn block_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     if handlers.options().translation_mode == TranslationMode::Pure {
         let content = handlers.walk_children(element.node).content;
-        let content = content.trim_matches('\n');
-        Some(concat_strings!("\n\n", content, "\n\n").into())
+        Some(frame_as_block(&content).into())
     } else {
-        Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        })
+        Some(serialize_element_result(handlers, &element))
     }
 }
 

--- a/src/element_handler/p.rs
+++ b/src/element_handler/p.rs
@@ -2,12 +2,11 @@ use crate::{
     Element,
     element_handler::{HandlerResult, Handlers},
     serialize_if_faithful,
-    text_util::concat_strings,
+    text_util::frame_as_block,
 };
 
 pub(super) fn p_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_faithful!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
-    let content = content.trim_matches('\n');
-    Some(concat_strings!("\n\n", content, "\n\n").into())
+    Some(frame_as_block(&content).into())
 }

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -1,10 +1,13 @@
 use crate::{
     Element,
-    element_handler::{HandlerResult, Handlers, element_util::serialize_element},
+    element_handler::{
+        HandlerResult, Handlers,
+        element_util::{serialize_element, serialize_element_result},
+    },
     node_util::get_node_tag_name,
     options::TranslationMode,
     serialize_if_faithful,
-    text_util::concat_strings,
+    text_util::frame_as_block,
 };
 
 pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
@@ -31,18 +34,11 @@ pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<H
         if handlers.options().translation_mode == TranslationMode::Faithful
             && !result.markdown_translated
         {
-            return Some(HandlerResult {
-                content: serialize_element(handlers, &element),
-                markdown_translated: false,
-            });
+            return Some(HandlerResult::html(serialize_element(handlers, &element)));
         }
 
-        let content = result.content.trim_matches('\n');
-        Some(concat_strings!("\n\n", content, "\n\n").into())
+        Some(frame_as_block(&result.content).into())
     } else {
-        Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        })
+        Some(serialize_element_result(handlers, &element))
     }
 }

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,9 +1,9 @@
-use crate::element_handler::element_util::serialize_element;
+use crate::element_handler::element_util::serialize_element_result;
 use crate::element_handler::{Element, HandlerResult, Handlers};
 use crate::node_util::{get_node_tag_name, get_parent_node};
 use crate::options::TranslationMode;
 use crate::serialize_if_faithful;
-use crate::text_util::{TrimDocumentWhitespace, concat_strings};
+use crate::text_util::{TrimDocumentWhitespace, concat_strings, frame_as_block};
 use markup5ever_rcdom::NodeData;
 use std::rc::Rc;
 
@@ -32,10 +32,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
 
     if handlers.options().translation_mode == TranslationMode::Faithful && !all_children_translated
     {
-        return Some(HandlerResult {
-            content: serialize_element(handlers, &element),
-            markdown_translated: false,
-        });
+        return Some(serialize_element_result(handlers, &element));
     }
 
     if rows.is_empty() && headers.is_empty() {
@@ -44,7 +41,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         if content.is_empty() {
             return None;
         }
-        return Some(concat_strings!("\n\n", content, "\n\n").into());
+        return Some(frame_as_block(content).into());
     }
 
     let num_columns = headers
@@ -128,13 +125,23 @@ fn extract_thead(
         .find(|node| get_node_tag_name(node).is_some_and(|tag| tag == "tr"))
         .unwrap_or(thead_node);
 
-    let (headers, translated) = extract_row_cells(handlers, row_node, "th");
-    table.headers = headers;
-    table.all_children_translated &= translated;
-    if table.headers.is_empty() {
-        let (headers, translated) = extract_row_cells(handlers, row_node, "td");
-        table.headers = headers;
+    extract_header_row(handlers, row_node, table);
+}
+
+/// Fills `table.headers` from `row_node`, preferring its `th` cells and falling
+/// back to its `td` cells when it holds no `th`.
+fn extract_header_row(
+    handlers: &dyn Handlers,
+    row_node: &Rc<markup5ever_rcdom::Node>,
+    table: &mut ExtractedTable,
+) {
+    for cell_tag in ["th", "td"] {
+        let (headers, translated) = extract_row_cells(handlers, row_node, cell_tag);
         table.all_children_translated &= translated;
+        table.headers = headers;
+        if !table.headers.is_empty() {
+            break;
+        }
     }
 }
 
@@ -174,14 +181,7 @@ fn extract_direct_row(
     has_thead: &mut bool,
 ) {
     if !*has_thead && table.headers.is_empty() {
-        let (headers, translated) = extract_row_cells(handlers, row_node, "th");
-        table.headers = headers;
-        table.all_children_translated &= translated;
-        if table.headers.is_empty() {
-            let (headers, translated) = extract_row_cells(handlers, row_node, "td");
-            table.headers = headers;
-            table.all_children_translated &= translated;
-        }
+        extract_header_row(handlers, row_node, table);
         *has_thead = !table.headers.is_empty();
     } else {
         let (cells, translated) = extract_row_cells(handlers, row_node, "td");

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -134,6 +134,14 @@ pub(crate) fn append_block(output: &mut String, content: &str) {
     output.push_str(content_without_newlines);
 }
 
+/// Frames `content` as a CommonMark block: any newlines already around it are
+/// dropped and a blank line is written on either side. The walk collapses a run
+/// of newlines at a boundary to two, so blocks framed this way end up separated
+/// by exactly one blank line however they are combined.
+pub(crate) fn frame_as_block(content: &str) -> String {
+    concat_strings!("\n\n", content.trim_matches('\n'), "\n\n")
+}
+
 pub(crate) fn compress_whitespace(input: &str) -> Cow<'_, str> {
     if input.is_empty() {
         return Cow::Borrowed(input);


### PR DESCRIPTION
Some DRY/refactoring to clean up the current implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown block formatting across paragraphs, blockquotes, lists, tables, HTML, and preformatted content.
  * Improved faithful-mode handling so content that cannot be translated remains preserved as HTML.
  * Improved table header detection, including tables that use either header or data cells.
  * Preserved existing escaping behavior for HTML, structural prefixes, and ordered-list punctuation.

* **Refinements**
  * Improved consistency when handling nested and preformatted elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->