### PR TITLE
Refactor: replace serialize_if_faithful! with two scoped macros.

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -2,9 +2,9 @@ use std::cell::RefCell;
 
 use crate::{
     Element, ElementHandler,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::{LinkReferenceStyle, LinkStyle},
-    serialize_if_faithful,
     text_util::{StripWhitespace, TrimDocumentWhitespace, concat_strings},
 };
 
@@ -72,7 +72,7 @@ impl ElementHandler for AnchorElementHandler {
                 title = Some(attr.value.to_string());
             } else {
                 // This is an attribute which can't be translated to Markdown.
-                serialize_if_faithful!(handlers, element, 0);
+                serialize_if_extra_attrs!(handlers, element, 0);
             }
         }
 

--- a/src/element_handler/blockquote.rs
+++ b/src/element_handler/blockquote.rs
@@ -1,7 +1,7 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings, frame_as_block},
 };
 
@@ -9,7 +9,7 @@ pub(super) fn blockquote_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
     let content = content.trim_start_matches('\n');
     let content = content

--- a/src/element_handler/br.rs
+++ b/src/element_handler/br.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::{BrStyle, TranslationMode},
-    serialize_if_faithful,
 };
 
 pub(super) fn br_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(
+    serialize_if_extra_attrs!(
         handlers,
         element,
         // In faithful mode, only emit `<br>`, not one of the problematic CommonMark encodings.

--- a/src/element_handler/caption.rs
+++ b/src/element_handler/caption.rs
@@ -1,11 +1,11 @@
 use crate::{
     Element,
     element_handler::element_util::handle_or_serialize_by_parent,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
 };
 
 pub(super) fn caption_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     handle_or_serialize_by_parent(handlers, &element, &["table"], true)
 }

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -5,10 +5,10 @@ use markup5ever_rcdom::{Node, NodeData};
 
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::{get_node_tag_name, get_parent_node},
     options::{CodeBlockFence, CodeBlockStyle, TranslationMode},
-    serialize_if_faithful,
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings},
 };
 
@@ -59,7 +59,7 @@ fn handle_code_block(
                 None
             }
         });
-        serialize_if_faithful!(handlers, element, if language.is_none() { 0 } else { 1 });
+        serialize_if_extra_attrs!(handlers, element, if language.is_none() { 0 } else { 1 });
         let mut result = String::from(&fence);
         if let Some(ref lang) = language {
             result.push_str(lang);
@@ -70,7 +70,7 @@ fn handle_code_block(
         result.push_str(&fence);
         Some(result.into())
     } else {
-        serialize_if_faithful!(handlers, element, 0);
+        serialize_if_extra_attrs!(handlers, element, 0);
         let code = content
             .lines()
             .map(|line| concat_strings!("    ", line))
@@ -114,7 +114,7 @@ fn find_language_from_attrs(attrs: &[Attribute]) -> Option<String> {
 }
 
 fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
     let preserve_boundary_spaces = handlers.options().preformatted_code
         && content.starts_with(' ')

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -10,6 +10,21 @@ use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer, TraversalS
 use markup5ever_rcdom::{NodeData, SerializableHandle};
 use std::io::{self, Write};
 
+/// Returns from the enclosing handler with `content` as the element's HTML,
+/// but only in faithful mode and only when `condition` holds. Pure mode has no
+/// HTML to fall back on, so it always translates.
+macro_rules! serialize_when_faithful {
+    ($handlers:expr, $condition:expr, $content:expr) => {
+        if $handlers.options().translation_mode == $crate::options::TranslationMode::Faithful
+            && $condition
+        {
+            return Some($crate::element_handler::HandlerResult::html($content));
+        }
+    };
+}
+
+pub(crate) use serialize_when_faithful;
+
 /// Handles a structural element when it has an allowed parent, or preserves it
 /// as HTML in faithful mode when it appears elsewhere.
 ///
@@ -148,21 +163,21 @@ where
     }
 }
 
-#[macro_export]
-macro_rules! serialize_if_faithful {
+/// Returns from the enclosing handler with `element` written as HTML when it
+/// carries more attributes than its Markdown translation can express.
+/// `num_attrs_allowed` of -1 rejects every attribute set, serializing the
+/// element whenever the mode is faithful; [`i64::MAX`] accepts any.
+macro_rules! serialize_if_extra_attrs {
     ($handlers:expr, $element:expr, $num_attrs_allowed:expr) => {
-        if $handlers.options().translation_mode == $crate::options::TranslationMode::Faithful
-            && $element.attrs.len() as i64 > $num_attrs_allowed
-        {
-            return Some($crate::element_handler::HandlerResult {
-                content: $crate::element_handler::element_util::serialize_element(
-                    $handlers, &$element,
-                ),
-                markdown_translated: false,
-            });
-        }
+        $crate::element_handler::element_util::serialize_when_faithful!(
+            $handlers,
+            $element.attrs.len() as i64 > $num_attrs_allowed,
+            $crate::element_handler::element_util::serialize_element($handlers, &$element)
+        )
     };
 }
+
+pub(crate) use serialize_if_extra_attrs;
 
 #[cfg(test)]
 mod tests {

--- a/src/element_handler/emphasis.rs
+++ b/src/element_handler/emphasis.rs
@@ -1,7 +1,7 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
     text_util::{StripWhitespace, concat_strings},
 };
 
@@ -10,7 +10,7 @@ pub(super) fn emphasis_handler(
     element: Element,
     marker: &str,
 ) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
     if content.is_empty() {
         return None;

--- a/src/element_handler/headings.rs
+++ b/src/element_handler/headings.rs
@@ -1,13 +1,13 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::HeadingStyle,
-    serialize_if_faithful,
     text_util::TrimDocumentWhitespace,
 };
 
 pub(super) fn headings_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let level = element.tag.chars().nth(1).unwrap() as u32 - '0' as u32;
     let content = handlers.walk_children(element.node).content;
     let content = content.trim_document_whitespace();

--- a/src/element_handler/hr.rs
+++ b/src/element_handler/hr.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::HrStyle,
-    serialize_if_faithful,
 };
 
 pub(super) fn hr_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     match handlers.options().hr_style {
         HrStyle::Dashes => Some("\n\n- - -\n\n".into()),
         HrStyle::Asterisks => Some("\n\n* * *\n\n".into()),

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -1,7 +1,7 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings},
 };
 
@@ -20,7 +20,7 @@ pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<H
         } else if name == "title" {
             title = Some(attr.value.to_string());
         } else {
-            serialize_if_faithful!(handlers, element, 0);
+            serialize_if_extra_attrs!(handlers, element, 0);
         }
     }
 

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -1,9 +1,9 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     node_util::{get_node_tag_name, get_parent_node},
     options::BulletListMarker,
-    serialize_if_faithful,
     text_util::{TrimDocumentWhitespace, concat_strings, indent_text_except_first_line},
 };
 
@@ -11,7 +11,7 @@ pub(super) fn list_item_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let mut content = handlers.walk_children(element.node).content;
     let start = content.len() - content.trim_start_document_whitespace().len();
     if start > 0 {

--- a/src/element_handler/list.rs
+++ b/src/element_handler/list.rs
@@ -2,10 +2,10 @@ use markup5ever_rcdom::NodeData;
 
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::{get_node_tag_name, get_parent_node},
     options::{Options, TranslationMode},
-    serialize_if_faithful,
     text_util::{append_block, concat_strings, frame_as_block, indent_text_except_first_line},
 };
 
@@ -17,7 +17,7 @@ pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<
             .attrs
             .first()
             .is_some_and(|attr| &attr.name.local == "start");
-        serialize_if_faithful!(handlers, element, if has_start { 1 } else { 0 });
+        serialize_if_extra_attrs!(handlers, element, if has_start { 1 } else { 0 });
 
         // ...all children must be translated as Markdown, and all children must
         // be li elements.

--- a/src/element_handler/p.rs
+++ b/src/element_handler/p.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
     text_util::frame_as_block,
 };
 
 pub(super) fn p_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     let content = handlers.walk_children(element.node).content;
     Some(frame_as_block(&content).into())
 }

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -1,17 +1,17 @@
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{
         HandlerResult, Handlers,
         element_util::{serialize_element, serialize_element_result},
     },
     node_util::get_node_tag_name,
     options::TranslationMode,
-    serialize_if_faithful,
     text_util::frame_as_block,
 };
 
 pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     // The only faithful translation for this is from
     // `<pre><code>blah</code></pre>` to a code block. So, check that this node
     // has only one element, a pure `<code>` element. Cases:

--- a/src/element_handler/span.rs
+++ b/src/element_handler/span.rs
@@ -2,8 +2,8 @@ use markup5ever_rcdom::NodeData;
 
 use crate::{
     Element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
     text_util::concat_strings,
 };
 
@@ -26,7 +26,7 @@ pub(super) fn span_handler(handlers: &dyn Handlers, element: Element) -> Option<
     }
 
     // Always serialize as HTML if we're in faithful mode.
-    serialize_if_faithful!(handlers, element, -1);
+    serialize_if_extra_attrs!(handlers, element, -1);
 
     // Otherwise, just return the contents.
     let content = handlers.walk_children(element.node).content;

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,8 +1,8 @@
 use crate::element_handler::element_util::serialize_element_result;
+use crate::element_handler::element_util::serialize_if_extra_attrs;
 use crate::element_handler::{Element, HandlerResult, Handlers};
 use crate::node_util::{get_node_tag_name, get_parent_node};
 use crate::options::TranslationMode;
-use crate::serialize_if_faithful;
 use crate::text_util::{TrimDocumentWhitespace, concat_strings, frame_as_block};
 use markup5ever_rcdom::NodeData;
 use std::rc::Rc;
@@ -16,7 +16,7 @@ use std::rc::Rc;
 /// | Cell1   | Cell2   |
 /// ```
 pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     if handlers.options().translation_mode == TranslationMode::Pure
         && (!has_explicit_headers(element.node) || is_inside_table_cell(element.node))
     {

--- a/src/element_handler/tbody.rs
+++ b/src/element_handler/tbody.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
     element_handler::element_util::handle_or_serialize_by_parent,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
 };
 
 pub(super) fn tbody_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     // This tag's ability to translate to markdown requires its children to be
     // markdown translatable as well.
     handle_or_serialize_by_parent(handlers, &element, &["table"], true)

--- a/src/element_handler/td_th.rs
+++ b/src/element_handler/td_th.rs
@@ -1,10 +1,10 @@
 use crate::{
     Element,
     dom_walker::is_block_element,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers, element_util::handle_or_serialize_by_parent},
     node_util::get_node_tag_name,
     options::TranslationMode,
-    serialize_if_faithful,
 };
 
 pub(super) fn td_th_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
@@ -16,7 +16,7 @@ pub(super) fn td_th_handler(handlers: &dyn Handlers, element: Element) -> Option
             .borrow()
             .iter()
             .any(|child| get_node_tag_name(child).is_some_and(is_block_element));
-    serialize_if_faithful!(
+    serialize_if_extra_attrs!(
         handlers,
         element,
         // Force HTML serialization in faithful mode if the table cell contains

--- a/src/element_handler/thead.rs
+++ b/src/element_handler/thead.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
     element_handler::element_util::handle_or_serialize_by_parent,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
 };
 
 pub(super) fn thead_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     // This tag's ability to translate to markdown requires its children to be
     // markdown translatable as well.
     handle_or_serialize_by_parent(handlers, &element, &["table"], true)

--- a/src/element_handler/tr.rs
+++ b/src/element_handler/tr.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
     element_handler::element_util::handle_or_serialize_by_parent,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    serialize_if_faithful,
 };
 
 pub(super) fn tr_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_faithful!(handlers, element, 0);
+    serialize_if_extra_attrs!(handlers, element, 0);
     // This tag's ability to translate to markdown requires its children to be
     // markdown translatable as well.
     handle_or_serialize_by_parent(handlers, &element, &["tbody", "thead"], true)


### PR DESCRIPTION
`serialize_if_faithful!` conflated two ideas: "we are in faithful mode and some condition holds, so write HTML" and the particular condition "this element has more attributes than Markdown can express". Splitting them gives `serialize_when_faithful!`, which takes the condition, and `serialize_if_extra_attrs!`, which is that one condition expressed in terms of it. Every existing call site becomes the latter, unchanged in meaning.

BREAKING: `serialize_if_faithful!` was `#[macro_export]`ed and so reachable as `htmd::serialize_if_faithful!`. It is removed rather than renamed; the replacements are crate-internal (`pub(crate) use`), since both expand to crate-private paths and were never usable from outside in practice.

No behavior change: the test suite is untouched and passes as it stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML serialization across supported elements when content contains attributes that cannot be represented in Markdown.
  - Preserved faithful HTML output only when needed, based on extra or unsupported attributes.
  - Applied consistent handling to links, blocks, code, images, lists, tables, headings, and other formatted elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->