### PR TITLE
Refactor: unify the anchor and img title normalizers.

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -5,7 +5,7 @@ use crate::{
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::{LinkReferenceStyle, LinkStyle},
-    text_util::{StripWhitespace, TrimDocumentWhitespace, concat_strings},
+    text_util::{StripWhitespace, concat_strings, normalize_title},
 };
 
 /// Handler for HTML `<a>` (anchor) elements.
@@ -81,7 +81,7 @@ impl ElementHandler for AnchorElementHandler {
         };
 
         // Handle new lines in title
-        let title = title.map(|text| process_title(&text));
+        let title = title.as_deref().map(normalize_title);
 
         let link = escape_link_destination(link);
 
@@ -199,28 +199,4 @@ fn escape_link_destination(link: String) -> String {
         }
     }
     escaped
-}
-
-fn process_title(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut wrote_any = false;
-
-    for line in text.lines() {
-        let line = line.trim_document_whitespace();
-        if line.is_empty() {
-            continue;
-        }
-        if wrote_any {
-            result.push('\n');
-        }
-        for ch in line.chars() {
-            if ch == '"' {
-                result.push('\\');
-            }
-            result.push(ch);
-        }
-        wrote_any = true;
-    }
-
-    result
 }

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -2,7 +2,7 @@ use crate::{
     Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings},
+    text_util::{concat_strings, normalize_title},
 };
 
 pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
@@ -26,18 +26,9 @@ pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<H
 
     link.as_ref()?;
 
-    let process_alt_title = |text: String| {
-        text.lines()
-            .map(|line| line.trim_document_whitespace().replace('"', "\\\""))
-            .filter(|line| !line.is_empty())
-            .join("\n")
-    };
-
-    // Handle new lines in alt
-    let alt = alt.map(process_alt_title);
-
-    // Handle new lines in title
-    let title = title.map(process_alt_title);
+    // Handle new lines in alt and in title
+    let alt = alt.as_deref().map(normalize_title);
+    let title = title.as_deref().map(normalize_title);
 
     let link = link.map(|text| text.replace('(', "\\(").replace(')', "\\)"));
 

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -142,6 +142,30 @@ pub(crate) fn frame_as_block(content: &str) -> String {
     concat_strings!("\n\n", content.trim_matches('\n'), "\n\n")
 }
 
+/// Normalizes an `alt` or `title` attribute value for Markdown: each line is
+/// trimmed of document whitespace, blank lines are dropped, every `"` is
+/// escaped so the value can sit inside a quoted title, and what is left is
+/// joined with a newline.
+pub(crate) fn normalize_title(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    for line in text.lines() {
+        let line = line.trim_document_whitespace();
+        if line.is_empty() {
+            continue;
+        }
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        for ch in line.chars() {
+            match ch {
+                '"' => result.push_str("\\\""),
+                _ => result.push(ch),
+            }
+        }
+    }
+    result
+}
+
 pub(crate) fn compress_whitespace(input: &str) -> Cow<'_, str> {
     if input.is_empty() {
         return Cow::Borrowed(input);


### PR DESCRIPTION
`anchor::process_title` and the `process_alt_title` closure in `img` did the same four things to an attribute value — trim each line, drop the blank ones, escape every quote, rejoin with a newline — differing only in the order of the escape and the blank-line filter, which cannot change the result. Both become `text_util::normalize_title`.

No behavior change: the test suite is untouched and passes as it stands. What that function emits changes in a later commit; this one only removes the second copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of link titles and image alternative text.
  * Removed unnecessary whitespace and blank lines from title and alternative text values.
  * Preserved intended line breaks while ensuring quotation marks are safely formatted in Markdown output.
  * Applied consistent text handling across links and images for more reliable rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->