### PR TITLE
Refactor: bundle the walk parameters into WalkState.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -13,17 +13,29 @@ use super::{
     },
 };
 
+/// The state a walk carries down through a subtree unchanged. `parent_tag` and
+/// `trim_leading_spaces` are deliberately not part of it: [`walk_children`]
+/// recomputes both for every child, while this describes the surroundings every
+/// descendant shares.
+#[derive(Clone, Copy)]
+pub(crate) struct WalkState {
+    /// Whether the node sits inside a `<pre>` or `<code>`, where whitespace is
+    /// preserved and text goes out unescaped.
+    pub(crate) is_pre: bool,
+}
+
 pub(crate) fn walk_node(
     node: &Rc<Node>,
     output: &mut String,
     handlers: &ElementHandlers,
     parent_tag: Option<&str>,
     trim_leading_spaces: bool,
-    is_pre: bool,
+    state: WalkState,
 ) -> bool {
     match &node.data {
         NodeData::Document => {
-            let _ = walk_children(node, output, handlers, true, false);
+            let root = WalkState { is_pre: false };
+            let _ = walk_children(node, output, handlers, true, root);
             trim_output_end(output);
             true
         }
@@ -32,7 +44,7 @@ pub(crate) fn walk_node(
             output,
             parent_tag,
             trim_leading_spaces,
-            is_pre,
+            state.is_pre,
         ),
         NodeData::Element { name, attrs, .. } => walk_element(
             node,
@@ -40,7 +52,7 @@ pub(crate) fn walk_node(
             &attrs.borrow(),
             output,
             handlers,
-            is_pre,
+            state,
         ),
         NodeData::Comment { contents } => {
             if handlers.options.translation_mode == TranslationMode::Faithful {
@@ -100,13 +112,13 @@ fn walk_element(
     attrs: &[html5ever::Attribute],
     output: &mut String,
     handlers: &ElementHandlers,
-    is_pre: bool,
+    state: WalkState,
 ) -> bool {
     if is_passthrough_span(tag, attrs, handlers) {
         let mut content = String::new();
-        let markdown_translated = walk_children(node, &mut content, handlers, false, is_pre);
+        let markdown_translated = walk_children(node, &mut content, handlers, false, state);
         trim_newlines(&mut content);
-        append_normalized_content(output, content, is_pre);
+        append_normalized_content(output, content, state.is_pre);
         return markdown_translated;
     }
 
@@ -114,9 +126,9 @@ fn walk_element(
         && !handlers.tag_to_handler_indices.contains_key(tag)
     {
         let mut content = String::new();
-        let markdown_translated =
-            walk_children(node, &mut content, handlers, is_block_element(tag), is_pre);
-        append_normalized_content(output, content, is_pre);
+        let is_block = is_block_element(tag);
+        let markdown_translated = walk_children(node, &mut content, handlers, is_block, state);
+        append_normalized_content(output, content, state.is_pre);
         return markdown_translated;
     }
 
@@ -124,7 +136,7 @@ fn walk_element(
         return true;
     };
     if !result.content.is_empty() || tag != "head" {
-        append_normalized_content(output, result.content, is_pre);
+        append_normalized_content(output, result.content, state.is_pre);
     }
     result.markdown_translated
 }
@@ -213,10 +225,11 @@ pub(crate) fn walk_children(
     output: &mut String,
     handlers: &ElementHandlers,
     is_parent_block_element: bool,
-    is_pre: bool,
+    // The state the children are walked in.
+    state: WalkState,
     // Return value: `markdown_translated`.
 ) -> bool {
-    let mut trim_leading_spaces = !is_pre && is_parent_block_element;
+    let mut trim_leading_spaces = !state.is_pre && is_parent_block_element;
     let tag = match &node.data {
         NodeData::Document => Some("html"),
         NodeData::Element { name, .. } => Some(name.local.as_ref()),
@@ -251,7 +264,7 @@ pub(crate) fn walk_children(
 
         let output_len = output.len();
 
-        markdown_translated &= walk_node(child, output, handlers, tag, trim_leading_spaces, is_pre);
+        markdown_translated &= walk_node(child, output, handlers, tag, trim_leading_spaces, state);
 
         if output.len() > output_len {
             // Something was appended, update the flag

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -21,7 +21,7 @@ mod td_th;
 mod tr;
 
 use crate::{
-    dom_walker::walk_node,
+    dom_walker::{WalkState, walk_node},
     element_handler::element_util::serialize_element_result,
     options::{Options, TranslationMode},
     text_util::frame_as_block,
@@ -279,8 +279,10 @@ impl Handlers for ElementHandlers {
 
     fn handle(&self, node: &Rc<Node>) -> Option<HandlerResult> {
         let mut output = String::new();
-        let markdown_translated =
-            walk_node(node, &mut output, self, None, true, is_inside_pre(node));
+        let state = WalkState {
+            is_pre: is_inside_pre(node),
+        };
+        let markdown_translated = walk_node(node, &mut output, self, None, true, state);
         Some(HandlerResult {
             content: output,
             markdown_translated,
@@ -291,9 +293,13 @@ impl Handlers for ElementHandlers {
         let mut output = String::new();
         let tag = crate::node_util::get_node_tag_name(node);
         let is_block = tag.is_some_and(crate::dom_walker::is_block_element);
-        let is_pre = tag.is_some_and(is_pre_element) || is_inside_pre(node);
+        let state = WalkState {
+            // Unlike `handle`, which walks the node itself, this walks inside
+            // it, so the node's own tag counts too.
+            is_pre: tag.is_some_and(is_pre_element) || is_inside_pre(node),
+        };
         let markdown_translated =
-            crate::dom_walker::walk_children(node, &mut output, self, is_block, is_pre);
+            crate::dom_walker::walk_children(node, &mut output, self, is_block, state);
         HandlerResult {
             content: output,
             markdown_translated,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub(crate) mod text_util;
 
 use std::rc::Rc;
 
-use dom_walker::walk_node;
+use dom_walker::{WalkState, walk_node};
 use element_handler::{ElementHandler, ElementHandlers, is_inside_pre};
 use html5ever::tendril::TendrilSink;
 use html5ever::tree_builder::TreeBuilderOpts;
@@ -136,7 +136,9 @@ impl HtmlToMarkdown {
             &self.handlers,
             None,
             true,
-            is_inside_pre(tree),
+            WalkState {
+                is_pre: is_inside_pre(tree),
+            },
         );
 
         // Trim leading/trailing newlines in place instead of allocating a copy.


### PR DESCRIPTION
`is_pre` is threaded unchanged through `walk_node` and `walk_children` and down into every descendant. Moving it into a `WalkState` gives that "state the whole subtree shares" a name, and gives the next commit somewhere to put a second such field without widening five signatures again.

`parent_tag` and `trim_leading_spaces` stay separate parameters on purpose: `walk_children` recomputes both per child, so they are not shared state.

No behavior change: the test suite is untouched and passes as it stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal traversal state handling was streamlined without changing user-visible behavior.
  * Existing processing of preformatted and code content remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->