### PR TITLE
Add: record the block/inline context of every walked node.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -3,7 +3,7 @@ use markup5ever_rcdom::{Node, NodeData};
 use phf::phf_set;
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
-use crate::element_handler::ElementHandlers;
+use crate::{Context, element_handler::ElementHandlers};
 
 use super::{
     options::TranslationMode,
@@ -15,13 +15,15 @@ use super::{
 
 /// The state a walk carries down through a subtree unchanged. `parent_tag` and
 /// `trim_leading_spaces` are deliberately not part of it: [`walk_children`]
-/// recomputes both for every child, while this describes the surroundings every
-/// descendant shares.
+/// recomputes both for every child, while these two describe the surroundings
+/// every descendant shares.
 #[derive(Clone, Copy)]
 pub(crate) struct WalkState {
     /// Whether the node sits inside a `<pre>` or `<code>`, where whitespace is
     /// preserved and text goes out unescaped.
     pub(crate) is_pre: bool,
+    /// The [`Context`] the node appears in.
+    pub(crate) context: Context,
 }
 
 pub(crate) fn walk_node(
@@ -34,7 +36,10 @@ pub(crate) fn walk_node(
 ) -> bool {
     match &node.data {
         NodeData::Document => {
-            let root = WalkState { is_pre: false };
+            let root = WalkState {
+                is_pre: false,
+                context: Context::Block,
+            };
             let _ = walk_children(node, output, handlers, true, root);
             trim_output_end(output);
             true
@@ -116,6 +121,7 @@ fn walk_element(
 ) -> bool {
     if is_passthrough_span(tag, attrs, handlers) {
         let mut content = String::new();
+        // A span holds inline content, so its children keep this context.
         let markdown_translated = walk_children(node, &mut content, handlers, false, state);
         trim_newlines(&mut content);
         append_normalized_content(output, content, state.is_pre);
@@ -132,7 +138,7 @@ fn walk_element(
         return markdown_translated;
     }
 
-    let Some(result) = handlers.handle(node, tag, attrs, true, 0) else {
+    let Some(result) = handlers.handle(node, tag, attrs, true, 0, state.context) else {
         return true;
     };
     if !result.content.is_empty() || tag != "head" {
@@ -225,7 +231,8 @@ pub(crate) fn walk_children(
     output: &mut String,
     handlers: &ElementHandlers,
     is_parent_block_element: bool,
-    // The state the children are walked in.
+    // The state the children are walked in; its context is the one they appear
+    // in.
     state: WalkState,
     // Return value: `markdown_translated`.
 ) -> bool {

--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -77,7 +77,7 @@ impl ElementHandler for AnchorElementHandler {
         }
 
         let Some(link) = link else {
-            return Some(handlers.walk_children(element.node));
+            return Some(handlers.walk_children(element.node, element.context));
         };
 
         // Handle new lines in title
@@ -85,7 +85,7 @@ impl ElementHandler for AnchorElementHandler {
 
         let link = escape_link_destination(link);
 
-        let content = handlers.walk_children(element.node).content;
+        let content = handlers.walk_children_content(element.node, element.context);
         let md = match handlers.options().link_style {
             LinkStyle::Inlined => {
                 self.build_inlined_anchor(&content, &link, title.as_deref(), false)

--- a/src/element_handler/blockquote.rs
+++ b/src/element_handler/blockquote.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings, frame_as_block},
@@ -10,7 +10,8 @@ pub(super) fn blockquote_handler(
     element: Element,
 ) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
-    let content = handlers.walk_children(element.node).content;
+    // A blockquote is a container block: its children begin a block context.
+    let content = handlers.walk_children_content(element.node, Context::Block);
     let content = content.trim_start_matches('\n');
     let content = content
         .trim_end_document_whitespace()

--- a/src/element_handler/caption.rs
+++ b/src/element_handler/caption.rs
@@ -1,9 +1,11 @@
 use crate::{
-    Element,
+    Context, Element,
     element_handler::element_util::handle_or_serialize_by_parent,
     element_handler::{HandlerResult, Handlers},
 };
 
 pub(super) fn caption_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    handle_or_serialize_by_parent(handlers, &element, &["table"], 0, true)
+    // A caption is written as a paragraph above the table, and a paragraph is a
+    // leaf block: its children begin an inline context.
+    handle_or_serialize_by_parent(handlers, &element, &["table"], 0, true, Context::Inline)
 }

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -44,7 +44,9 @@ fn handle_code_block(
     element: Element,
     parent: &Rc<Node>,
 ) -> Option<HandlerResult> {
-    let content = handlers.walk_children(element.node).content;
+    // `<code>` begins no block of its own, so it passes on its context: the
+    // inline context begun by the `<pre>` this is the code block of.
+    let content = handlers.walk_children_content(element.node, element.context);
     let content = content.strip_suffix('\n').unwrap_or(&content);
     if handlers.options().code_block_style == CodeBlockStyle::Fenced {
         let fence = if handlers.options().code_block_fence == CodeBlockFence::Tildes {
@@ -115,7 +117,9 @@ fn find_language_from_attrs(attrs: &[Attribute]) -> Option<String> {
 
 fn handle_inline_code(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
-    let content = handlers.walk_children(element.node).content;
+    // A code span holds literal text — every child is a text node here, as
+    // `code_handler` checked — so the context it is read in doesn't matter.
+    let content = handlers.walk_children_content(element.node, element.context);
     let preserve_boundary_spaces = handlers.options().preformatted_code
         && content.starts_with(' ')
         && content.ends_with(' ')

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     dom_walker::is_block_element,
     element_handler::{HandlerResult, Handlers},
     node_util::parent_tag_name_equals,
@@ -33,16 +33,17 @@ pub(crate) use serialize_when_faithful;
 /// attribute set, and [`i64::MAX`] accepts any. Either test serializes the same
 /// element, so the order they are tried in does not matter.
 ///
-/// Handled child content is framed as a block. When
-/// `propagate_children_translation` is true, the returned translation status
-/// is false if any child required HTML; callers can use that status to fall
-/// back to serializing a larger containing structure.
+/// Handled child content is framed as a block, and translated in
+/// `children_context`. When `propagate_children_translation` is true, the
+/// returned translation status is false if any child required HTML; callers can
+/// use that status to fall back to serializing a larger containing structure.
 pub(super) fn handle_or_serialize_by_parent(
     handlers: &dyn Handlers,
     element: &Element,
     tag_names: &[&str],
     num_attrs_allowed: i64,
     propagate_children_translation: bool,
+    children_context: Context,
 ) -> Option<HandlerResult> {
     serialize_when_faithful!(
         handlers,
@@ -50,7 +51,7 @@ pub(super) fn handle_or_serialize_by_parent(
             || !parent_tag_name_equals(element.node, tag_names),
         serialize_element(handlers, element)
     );
-    let result = handlers.walk_children(element.node);
+    let result = handlers.walk_children(element.node, children_context);
     Some(HandlerResult {
         content: frame_as_block(&result.content),
         markdown_translated: !propagate_children_translation || result.markdown_translated,
@@ -104,7 +105,13 @@ fn serialize_inline_element(
     )?;
     serializer
         .writer
-        .write_all(handlers.walk_children(element.node).content.as_bytes())?;
+        // What a raw HTML inline holds is inline content, whatever context the
+        // element itself appears in.
+        .write_all(
+            handlers
+                .walk_children_content(element.node, Context::Inline)
+                .as_bytes(),
+        )?;
     serializer.end_elem(name.clone())?;
     String::from_utf8(bytes).map_err(io::Error::other)
 }

--- a/src/element_handler/emphasis.rs
+++ b/src/element_handler/emphasis.rs
@@ -11,7 +11,7 @@ pub(super) fn emphasis_handler(
     marker: &str,
 ) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
-    let content = handlers.walk_children(element.node).content;
+    let content = handlers.walk_children_content(element.node, element.context);
     if content.is_empty() {
         return None;
     }

--- a/src/element_handler/head_body.rs
+++ b/src/element_handler/head_body.rs
@@ -8,5 +8,12 @@ pub(super) fn head_body_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    handle_or_serialize_by_parent(handlers, &element, &["html"], i64::MAX, false)
+    handle_or_serialize_by_parent(
+        handlers,
+        &element,
+        &["html"],
+        i64::MAX,
+        false,
+        element.context,
+    )
 }

--- a/src/element_handler/headings.rs
+++ b/src/element_handler/headings.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::HeadingStyle,
@@ -9,7 +9,8 @@ use crate::{
 pub(super) fn headings_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
     let level = element.tag.chars().nth(1).unwrap() as u32 - '0' as u32;
-    let content = handlers.walk_children(element.node).content;
+    // A heading is a leaf block: its children begin an inline context.
+    let content = handlers.walk_children_content(element.node, Context::Inline);
     let content = content.trim_document_whitespace();
     let content = content.trim_matches('\n');
 

--- a/src/element_handler/html.rs
+++ b/src/element_handler/html.rs
@@ -16,7 +16,7 @@ pub(super) fn html_handler(handlers: &dyn Handlers, element: Element) -> Option<
             .is_some_and(|parent| matches!(parent.data, NodeData::Document));
 
     if markdown_translatable {
-        let content = handlers.walk_children(element.node).content;
+        let content = handlers.walk_children_content(element.node, element.context);
         Some(frame_as_block(&content).into())
     } else {
         Some(serialize_element_result(handlers, &element))

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     node_util::{get_node_tag_name, get_parent_node},
@@ -12,7 +12,8 @@ pub(super) fn list_item_handler(
     element: Element,
 ) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
-    let mut content = handlers.walk_children(element.node).content;
+    // A list item is a container block: its children begin a block context.
+    let mut content = handlers.walk_children_content(element.node, Context::Block);
     let start = content.len() - content.trim_start_document_whitespace().len();
     if start > 0 {
         content.drain(..start);

--- a/src/element_handler/list.rs
+++ b/src/element_handler/list.rs
@@ -44,7 +44,9 @@ pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<
             markdown_translated: translated,
         }
     } else {
-        handlers.walk_children(element.node)
+        // A list isn't a leaf or container block, so it passes on its context;
+        // the list items it holds are the container blocks.
+        handlers.walk_children(element.node, element.context)
     };
 
     if handlers.options().translation_mode == TranslationMode::Faithful
@@ -83,7 +85,7 @@ fn get_ol_content(handlers: &dyn Handlers, element: &Element) -> (String, bool) 
         .unwrap_or(1);
 
     for child in element.node.children.borrow().iter() {
-        let Some(res) = handlers.handle(child) else {
+        let Some(res) = handlers.handle(child, element.context) else {
             continue;
         };
         if !res.markdown_translated {

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     text_util::frame_as_block,
 };
 
-use super::Element;
+use super::{Context, Element};
 use anchor::AnchorElementHandler;
 use blockquote::blockquote_handler;
 use br::br_handler;
@@ -221,12 +221,14 @@ impl ElementHandlers {
         attrs: &[Attribute],
         markdown_translated: bool,
         skipped_handlers: usize,
+        context: Context,
     ) -> Option<HandlerResult> {
         let element = Element {
             node,
             tag,
             attrs,
             markdown_translated,
+            context,
             skipped_handlers,
         };
         match self.find_handler(tag, skipped_handlers) {
@@ -236,7 +238,7 @@ impl ElementHandlers {
                     Some(serialize_element_result(self, &element))
                 } else {
                     // Default behavior: walk children and return their content
-                    Some(self.walk_children(node))
+                    Some(self.walk_children(node, context))
                 }
             }
         }
@@ -256,11 +258,19 @@ pub trait Handlers {
     /// Skip the current handler and fall back to the previous handler (earlier in registration order).
     fn fallback(&self, element: Element) -> Option<HandlerResult>;
 
-    /// Process a `markup5ever` node through the handlers.
-    fn handle(&self, node: &Rc<Node>) -> Option<HandlerResult>;
+    /// Process a `markup5ever` node through the handlers. `context` is the
+    /// [`Context`] the node appears in.
+    fn handle(&self, node: &Rc<Node>, context: Context) -> Option<HandlerResult>;
 
-    /// Walks children of a node and returns both content and markdown_translated status.
-    fn walk_children(&self, node: &Rc<Node>) -> HandlerResult;
+    /// Walks children of a node and returns both content and markdown_translated
+    /// status.
+    fn walk_children(&self, node: &Rc<Node>, context: Context) -> HandlerResult;
+
+    /// The content of [`Handlers::walk_children`], for the many handlers whose
+    /// own translation status does not depend on their children's.
+    fn walk_children_content(&self, node: &Rc<Node>, context: Context) -> String {
+        self.walk_children(node, context).content
+    }
 
     /// Get the conversion options.
     fn options(&self) -> &Options;
@@ -274,13 +284,15 @@ impl Handlers for ElementHandlers {
             element.attrs,
             element.markdown_translated,
             element.skipped_handlers + 1,
+            element.context,
         )
     }
 
-    fn handle(&self, node: &Rc<Node>) -> Option<HandlerResult> {
+    fn handle(&self, node: &Rc<Node>, context: Context) -> Option<HandlerResult> {
         let mut output = String::new();
         let state = WalkState {
             is_pre: is_inside_pre(node),
+            context,
         };
         let markdown_translated = walk_node(node, &mut output, self, None, true, state);
         Some(HandlerResult {
@@ -289,7 +301,7 @@ impl Handlers for ElementHandlers {
         })
     }
 
-    fn walk_children(&self, node: &Rc<Node>) -> HandlerResult {
+    fn walk_children(&self, node: &Rc<Node>, context: Context) -> HandlerResult {
         let mut output = String::new();
         let tag = crate::node_util::get_node_tag_name(node);
         let is_block = tag.is_some_and(crate::dom_walker::is_block_element);
@@ -297,6 +309,7 @@ impl Handlers for ElementHandlers {
             // Unlike `handle`, which walks the node itself, this walks inside
             // it, so the node's own tag counts too.
             is_pre: tag.is_some_and(is_pre_element) || is_inside_pre(node),
+            context,
         };
         let markdown_translated =
             crate::dom_walker::walk_children(node, &mut output, self, is_block, state);
@@ -329,7 +342,7 @@ pub(crate) fn is_inside_pre(node: &Rc<Node>) -> bool {
 
 fn block_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     if handlers.options().translation_mode == TranslationMode::Pure {
-        let content = handlers.walk_children(element.node).content;
+        let content = handlers.walk_children_content(element.node, element.context);
         Some(frame_as_block(&content).into())
     } else {
         Some(serialize_element_result(handlers, &element))

--- a/src/element_handler/p.rs
+++ b/src/element_handler/p.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     text_util::frame_as_block,
@@ -7,6 +7,7 @@ use crate::{
 
 pub(super) fn p_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     serialize_if_extra_attrs!(handlers, element, 0);
-    let content = handlers.walk_children(element.node).content;
+    // A paragraph is a leaf block: its children begin an inline context.
+    let content = handlers.walk_children_content(element.node, Context::Inline);
     Some(frame_as_block(&content).into())
 }

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -29,7 +29,7 @@ pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<H
     };
 
     if handlers.options().translation_mode == TranslationMode::Pure || is_simple_code_block {
-        let result = handlers.walk_children(element.node);
+        let result = handlers.walk_children(element.node, element.context);
 
         if handlers.options().translation_mode == TranslationMode::Faithful
             && !result.markdown_translated

--- a/src/element_handler/span.rs
+++ b/src/element_handler/span.rs
@@ -29,7 +29,7 @@ pub(super) fn span_handler(handlers: &dyn Handlers, element: Element) -> Option<
     serialize_if_extra_attrs!(handlers, element, -1);
 
     // Otherwise, just return the contents.
-    let content = handlers.walk_children(element.node).content;
+    let content = handlers.walk_children_content(element.node, element.context);
     let content = content.trim_matches('\n');
 
     Some(content.into())

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,3 +1,4 @@
+use crate::Context;
 use crate::element_handler::element_util::serialize_element_result;
 use crate::element_handler::element_util::serialize_if_extra_attrs;
 use crate::element_handler::{Element, HandlerResult, Handlers};
@@ -36,7 +37,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
     }
 
     if rows.is_empty() && headers.is_empty() {
-        let content = handlers.walk_children(element.node).content;
+        let content = handlers.walk_children_content(element.node, element.context);
         let content = content.trim_matches('\n');
         if content.is_empty() {
             return None;
@@ -92,9 +93,11 @@ fn extract_table_content(
             continue;
         };
 
+        // A table only builds CommonMark in a block context, so its caption,
+        // sections, rows and cells all sit in one.
         match name.local.as_ref() {
             "caption" => {
-                if let Some(result) = handlers.handle(child) {
+                if let Some(result) = handlers.handle(child, Context::Block) {
                     table.all_children_translated &= result.markdown_translated;
                     table
                         .captions
@@ -242,7 +245,9 @@ fn extract_row_cells(
         if let NodeData::Element { name, .. } = &cell_node.data
             && name.local.as_ref() == cell_tag
         {
-            let Some(res) = handlers.handle(cell_node) else {
+            // See `extract_table_content`: a cell of a translated table is
+            // always in a block context.
+            let Some(res) = handlers.handle(cell_node, Context::Block) else {
                 continue;
             };
             if !res.markdown_translated {

--- a/src/element_handler/table_section.rs
+++ b/src/element_handler/table_section.rs
@@ -6,10 +6,11 @@ use crate::{
 
 /// Handler for the `<thead>` and `<tbody>` sections of a table. This tag's
 /// ability to translate to markdown requires its children to be markdown
-/// translatable as well.
+/// translatable as well. A section begins no block of its own, so it passes its
+/// context on; the cells its rows hold are the leaf blocks.
 pub(super) fn table_section_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    handle_or_serialize_by_parent(handlers, &element, &["table"], 0, true)
+    handle_or_serialize_by_parent(handlers, &element, &["table"], 0, true, element.context)
 }

--- a/src/element_handler/td_th.rs
+++ b/src/element_handler/td_th.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Element,
+    Context, Element,
     dom_walker::is_block_element,
     element_handler::element_util::handle_or_serialize_by_parent,
     element_handler::{HandlerResult, Handlers},
@@ -24,5 +24,8 @@ pub(super) fn td_th_handler(handlers: &dyn Handlers, element: Element) -> Option
         // block elements.
         if has_block_elements { -1 } else { 0 },
         false,
+        // A cell's contents are parsed as inline content, so no HTML block can
+        // open inside one.
+        Context::Inline,
     )
 }

--- a/src/element_handler/tr.rs
+++ b/src/element_handler/tr.rs
@@ -6,6 +6,14 @@ use crate::{
 
 pub(super) fn tr_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     // This tag's ability to translate to markdown requires its children to be
-    // markdown translatable as well.
-    handle_or_serialize_by_parent(handlers, &element, &["tbody", "thead"], 0, true)
+    // markdown translatable as well. A row begins no block of its own, so it
+    // passes on its context; the cells it holds are the leaf blocks.
+    handle_or_serialize_by_parent(
+        handlers,
+        &element,
+        &["tbody", "thead"],
+        0,
+        true,
+        element.context,
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,17 @@ pub fn convert(html: &str) -> Result<String, std::io::Error> {
     HtmlToMarkdown::new().convert(html)
 }
 
+/// The CommonMark context an element is translated in. See the "Translating
+/// HTML nodes" section of `unsupported_html.md`.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum Context {
+    /// A block may begin here: the document root and the contents of a
+    /// container block.
+    Block,
+    /// Only inline content may appear here: the contents of a leaf block.
+    Inline,
+}
+
 /// The DOM element.
 pub struct Element<'a> {
     /// The html5ever node of the element.
@@ -48,6 +59,10 @@ pub struct Element<'a> {
     /// likewise, translating lists ((`<ol>`/`<ul>`)`<li>`) to Markdown requires
     /// all `<li>` elements are translated to Markdown.
     pub markdown_translated: bool,
+    /// The [`Context`] this element appears in, as recorded by the walk which
+    /// produced it. An element which can only be written as HTML uses this to
+    /// pick between an HTML block and a raw HTML inline.
+    pub context: Context,
     /// The number of handlers to skip for this element.
     pub(crate) skipped_handlers: usize,
 }
@@ -138,6 +153,8 @@ impl HtmlToMarkdown {
             true,
             WalkState {
                 is_pre: is_inside_pre(tree),
+                // The root of the document is a block context.
+                context: Context::Block,
             },
         );
 

--- a/tests/code_tests.rs
+++ b/tests/code_tests.rs
@@ -96,7 +96,7 @@ fn delegated_unhandled_subtree_preserves_ancestor_preformatted_context() {
             vec!["delegate"],
             |handlers: &dyn Handlers, element: Element| {
                 let child = element.node.children.borrow().first()?.clone();
-                handlers.handle(&child)
+                handlers.handle(&child, element.context)
             },
         )
         .build();


### PR DESCRIPTION
Introduces `Context`, threads it down the walk in `WalkState`, and hands it to each handler as `Element::context`. Every handler declares the context its children appear in, following the "Translating HTML nodes" section of unsupported_html.md: headings, paragraphs and table cells are leaf blocks and begin an inline context; blockquotes and list items are container blocks and begin a block context; the document root is a block context; everything else passes on the context it was given.

Nothing reads the context yet. This commit is deliberately inert so that what it does can be reviewed as one question — is each handler declaring the right context? — separately from what later commits do with the answer. The test suite is untouched and passes as it stands.

BREAKING: `Handlers::handle` and `Handlers::walk_children` each take a `Context` argument, so custom handlers calling them need updating; the new `walk_children_content` is the common case of the latter. Adding the public `Element::context` field breaks nothing, as `Element` has a private field and so was never constructible outside the crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Markdown translation for nested HTML by preserving block and inline formatting context.
  * Improved handling of headings, paragraphs, lists, tables, captions, blockquotes, links, and code content.
  * Preserved preformatted behavior when processing nested elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->