### PR TITLE
Add: classify a serialized element by the context it appears in.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -503,6 +503,15 @@ fn escape_pre_text_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
     }
 }
 
+/// The tags which frame their content as a block rather than an inline run.
+///
+/// This is exactly CommonMark's
+/// [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks) type 1 list
+/// plus its type 6 list, and `element_util::try_serialize_element` relies on
+/// that: a tag outside both lists could only open a type 7 block, so it has to
+/// be written as a raw HTML inline instead. Keep this set in step with the spec
+/// — adding a tag here because it reads as block-like would silently change
+/// that classification.
 pub(crate) static BLOCK_ELEMENTS: phf::Set<&'static str> = phf_set! {
     "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption",
     "center", "col", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt",

--- a/src/element_handler/blockquote.rs
+++ b/src/element_handler/blockquote.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers},
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings, frame_as_block},
 };
@@ -9,7 +9,7 @@ pub(super) fn blockquote_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     // A blockquote is a container block: its children begin a block context.
     let content = handlers.walk_children_content(element.node, Context::Block);
     let content = content.trim_start_matches('\n');

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -27,7 +27,10 @@ pub(crate) use serialize_when_faithful;
 /// Handles a structural element when it has an allowed parent, or preserves it
 /// as HTML in faithful mode when it appears elsewhere.
 ///
-/// Faithful mode also writes the element as HTML when it carries more
+/// Every element handled here is part of a CommonMark block, so faithful mode
+/// also writes it as HTML when it appears in an inline context, where no block
+/// may begin; see the "Translating HTML nodes" section of
+/// `unsupported_html.md`. It does the same when the element carries more
 /// attributes than its Markdown translation can express, on the same terms as
 /// [`serialize_if_extra_attrs!`]: `num_attrs_allowed` of -1 rejects every
 /// attribute set, and [`i64::MAX`] accepts any. Either test serializes the same
@@ -47,7 +50,8 @@ pub(super) fn handle_or_serialize_by_parent(
 ) -> Option<HandlerResult> {
     serialize_when_faithful!(
         handlers,
-        element.attrs.len() as i64 > num_attrs_allowed
+        element.context == Context::Inline
+            || element.attrs.len() as i64 > num_attrs_allowed
             || !parent_tag_name_equals(element.node, tag_names),
         serialize_element(handlers, element)
     );
@@ -59,8 +63,8 @@ pub(super) fn handle_or_serialize_by_parent(
 }
 
 /// The [`HandlerResult`] for an element which can only be written as HTML: the
-/// element serialized, reported as not translated so that a container needing
-/// all-CommonMark children can serialize itself instead.
+/// element serialized per its [`Context`], reported as not translated so that a
+/// container needing all-CommonMark children can serialize itself instead.
 pub(crate) fn serialize_element_result(
     handlers: &dyn Handlers,
     element: &Element,
@@ -73,15 +77,24 @@ pub(crate) fn serialize_element(handlers: &dyn Handlers, element: &Element) -> S
 }
 
 fn try_serialize_element(handlers: &dyn Handlers, element: &Element) -> io::Result<String> {
-    let options = SerializeOpts {
+    // An element which can't be translated to CommonMark is an HTML block only
+    // where a block may begin *and* its tag opens one. A tag outside the type 1
+    // and 6 lists would instead open a type 7 HTML block, which cannot
+    // interrupt a paragraph and which swallows every following line down to the
+    // next blank one; a raw HTML inline is what such a tag needs, whatever the
+    // context. See the "Translating HTML nodes" section of
+    // `unsupported_html.md`.
+    if element.context == Context::Block && is_block_element(element.tag) {
+        serialize_block_element(element, serialize_opts())
+    } else {
+        serialize_inline_element(handlers, element, serialize_opts())
+    }
+}
+
+fn serialize_opts() -> SerializeOpts {
+    SerializeOpts {
         traversal_scope: TraversalScope::IncludeNode,
         ..Default::default()
-    };
-
-    if is_block_element(element.tag) {
-        serialize_block_element(element, options)
-    } else {
-        serialize_inline_element(handlers, element, options)
     }
 }
 
@@ -191,6 +204,25 @@ macro_rules! serialize_if_extra_attrs {
 }
 
 pub(crate) use serialize_if_extra_attrs;
+
+/// [`serialize_if_extra_attrs!`] for a handler whose Markdown is a CommonMark
+/// block, which additionally needs a block context: a block can only be written
+/// where one may begin, so in an inline context the element is written as a raw
+/// HTML inline instead. See the "Translating HTML nodes" section of
+/// `unsupported_html.md`. Either test serializes the same element, so the order
+/// they are tried in does not matter.
+macro_rules! serialize_if_extra_attrs_or_inline {
+    ($handlers:expr, $element:expr, $num_attrs_allowed:expr) => {
+        $crate::element_handler::element_util::serialize_when_faithful!(
+            $handlers,
+            $element.context == $crate::Context::Inline
+                || $element.attrs.len() as i64 > $num_attrs_allowed,
+            $crate::element_handler::element_util::serialize_element($handlers, &$element)
+        )
+    };
+}
+
+pub(crate) use serialize_if_extra_attrs_or_inline;
 
 #[cfg(test)]
 mod tests {

--- a/src/element_handler/headings.rs
+++ b/src/element_handler/headings.rs
@@ -1,13 +1,13 @@
 use crate::{
     Context, Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers},
     options::HeadingStyle,
     text_util::TrimDocumentWhitespace,
 };
 
 pub(super) fn headings_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     let level = element.tag.chars().nth(1).unwrap() as u32 - '0' as u32;
     // A heading is a leaf block: its children begin an inline context.
     let content = handlers.walk_children_content(element.node, Context::Inline);

--- a/src/element_handler/hr.rs
+++ b/src/element_handler/hr.rs
@@ -1,12 +1,12 @@
 use crate::{
     Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers},
     options::HrStyle,
 };
 
 pub(super) fn hr_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     match handlers.options().hr_style {
         HrStyle::Dashes => Some("\n\n- - -\n\n".into()),
         HrStyle::Asterisks => Some("\n\n* * *\n\n".into()),

--- a/src/element_handler/li.rs
+++ b/src/element_handler/li.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers},
     node_util::{get_node_tag_name, get_parent_node},
     options::BulletListMarker,
@@ -11,7 +11,7 @@ pub(super) fn list_item_handler(
     handlers: &dyn Handlers,
     element: Element,
 ) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     // A list item is a container block: its children begin a block context.
     let mut content = handlers.walk_children_content(element.node, Context::Block);
     let start = content.len() - content.trim_start_document_whitespace().len();

--- a/src/element_handler/list.rs
+++ b/src/element_handler/list.rs
@@ -2,7 +2,7 @@ use markup5ever_rcdom::NodeData;
 
 use crate::{
     Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
     node_util::{get_node_tag_name, get_parent_node},
     options::{Options, TranslationMode},
@@ -12,12 +12,13 @@ use crate::{
 pub(super) fn list_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     // In faithful mode, ...
     if handlers.options().translation_mode == TranslationMode::Faithful {
-        // ...make sure this element's attributes can be translated as markdown.
+        // ...a list is a CommonMark block, so it needs a block context, and
+        // this element's attributes must be translatable as markdown.
         let has_start = element
             .attrs
             .first()
             .is_some_and(|attr| &attr.name.local == "start");
-        serialize_if_extra_attrs!(handlers, element, if has_start { 1 } else { 0 });
+        serialize_if_extra_attrs_or_inline!(handlers, element, if has_start { 1 } else { 0 });
 
         // ...all children must be translated as Markdown, and all children must
         // be li elements.

--- a/src/element_handler/p.rs
+++ b/src/element_handler/p.rs
@@ -1,12 +1,12 @@
 use crate::{
     Context, Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    element_handler::element_util::serialize_if_extra_attrs_or_inline,
     element_handler::{HandlerResult, Handlers},
     text_util::frame_as_block,
 };
 
 pub(super) fn p_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     // A paragraph is a leaf block: its children begin an inline context.
     let content = handlers.walk_children_content(element.node, Context::Inline);
     Some(frame_as_block(&content).into())

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,6 +1,6 @@
 use crate::Context;
 use crate::element_handler::element_util::serialize_element_result;
-use crate::element_handler::element_util::serialize_if_extra_attrs;
+use crate::element_handler::element_util::serialize_if_extra_attrs_or_inline;
 use crate::element_handler::{Element, HandlerResult, Handlers};
 use crate::node_util::{get_node_tag_name, get_parent_node};
 use crate::options::TranslationMode;
@@ -17,7 +17,9 @@ use std::rc::Rc;
 /// | Cell1   | Cell2   |
 /// ```
 pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    serialize_if_extra_attrs!(handlers, element, 0);
+    // A GFM table is a CommonMark block, so the extraction below always runs in
+    // a block context.
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     if handlers.options().translation_mode == TranslationMode::Pure
         && (!has_explicit_headers(element.node) || is_inside_table_cell(element.node))
     {

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -1,0 +1,197 @@
+//! Tests for the block/inline context an element is translated in, following
+//! the "Given an HTML node that can't be encoded as CommonMark" rule of
+//! `unsupported_html.md`.
+
+use pretty_assertions::assert_eq;
+
+mod common;
+use common::convert_faithful;
+
+#[test]
+fn html_at_the_document_root_is_a_block() {
+    assert_eq!(
+        "<div>a</div>\n\n<div>b</div>",
+        convert_faithful("<div>a</div><div>b</div>").unwrap()
+    );
+    assert_eq!(
+        "<div><br><br></div>",
+        convert_faithful("<div><br><br></div>").unwrap()
+    );
+    assert_eq!(
+        "# <div><p>a</p></div>",
+        convert_faithful("<h1><div><p>a</p></div></h1>").unwrap()
+    );
+}
+
+/// `br` is not a block-level tag name, so a lone `<br>` on a line would open a
+/// [type 7 HTML block][], which cannot interrupt a paragraph and swallows every
+/// following line down to the next blank one. Such a tag is therefore a raw
+/// HTML inline everywhere, block context included.
+///
+/// [type 7 HTML block]: https://spec.commonmark.org/0.31.2/#html-blocks
+#[test]
+fn a_type_7_tag_is_a_raw_inline_even_in_a_block_context() {
+    assert_eq!("<br>", convert_faithful("<br>").unwrap());
+    assert_eq!("<br><br>", convert_faithful("<br><br>").unwrap());
+    assert_eq!(
+        r#"This is <em foo="">really</em> important."#,
+        convert_faithful("This is <em foo>really</em> important.").unwrap()
+    );
+    assert_eq!(
+        "*   a<br>b",
+        convert_faithful("<ul><li>a<br>b</li></ul>").unwrap()
+    );
+    assert_eq!(
+        "> a<br>b",
+        convert_faithful("<blockquote>a<br>b</blockquote>").unwrap()
+    );
+    // A paragraph still frames itself as a block, so a `<br>` beside one does
+    // not join it.
+    assert_eq!("<br>\n\na", convert_faithful("<br><p>a</p>").unwrap());
+    assert_eq!("a\n\n<br>", convert_faithful("<p>a</p><br>").unwrap());
+}
+
+#[test]
+fn a_commonmark_block_in_an_inline_context_is_a_raw_inline() {
+    assert_eq!("# <p>a</p>", convert_faithful("<h1><p>a</p></h1>").unwrap());
+    assert_eq!(
+        "# x<p>a</p>y",
+        convert_faithful("<h1>x<p>a</p>y</h1>").unwrap()
+    );
+    assert_eq!(
+        "# <blockquote>a</blockquote>",
+        convert_faithful("<h1><blockquote>a</blockquote></h1>").unwrap()
+    );
+    assert_eq!(
+        "# <ul><li>a</li></ul>",
+        convert_faithful("<h1><ul><li>a</li></ul></h1>").unwrap()
+    );
+    assert_eq!("# <hr>", convert_faithful("<h1><hr></h1>").unwrap());
+    // Only the tags of a raw HTML inline are HTML; what it holds is still
+    // translated.
+    assert_eq!(
+        "# <table><thead><tr><th>h</th></tr></thead><tbody><tr><td>a</td></tr></tbody></table>",
+        convert_faithful(
+            "<h1><table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td>a</td></tr></tbody></table></h1>"
+        )
+        .unwrap()
+    );
+}
+
+/// Not a faithful translation: CommonMark provides no way to write raw text
+/// without opening a paragraph.
+#[test]
+fn raw_text_at_the_document_root_is_left_alone() {
+    assert_eq!("foo", convert_faithful("foo").unwrap());
+}
+
+#[test]
+fn html_in_a_paragraph_is_a_raw_inline() {
+    assert_eq!("<br><br>", convert_faithful("<p><br><br></p>").unwrap());
+    assert_eq!(
+        "<br>*b*",
+        convert_faithful("<p><br><em>b</em></p>").unwrap()
+    );
+    assert_eq!(
+        "*a*<br>",
+        convert_faithful("<p><em>a</em><br></p>").unwrap()
+    );
+    assert_eq!(
+        "<br>![](i)",
+        convert_faithful(r#"<p><br><img src="i"></p>"#).unwrap()
+    );
+}
+
+#[test]
+fn html_in_a_heading_is_a_raw_inline() {
+    assert_eq!("# <br><br>", convert_faithful("<h1><br><br></h1>").unwrap());
+    assert_eq!(
+        "# <br>*b*",
+        convert_faithful("<h1><br><em>b</em></h1>").unwrap()
+    );
+    assert_eq!(
+        "###### *a*<br>",
+        convert_faithful("<h6><em>a</em><br></h6>").unwrap()
+    );
+}
+
+#[test]
+fn html_in_a_blockquote_is_a_block() {
+    assert_eq!(
+        "> <div>a</div>\n> \n> <div>b</div>",
+        convert_faithful("<blockquote><div>a</div><div>b</div></blockquote>").unwrap()
+    );
+    assert_eq!(
+        "> <br><br>",
+        convert_faithful("<blockquote><br><br></blockquote>").unwrap()
+    );
+    assert_eq!(
+        "> <br>*b*",
+        convert_faithful("<blockquote><p><br><em>b</em></p></blockquote>").unwrap()
+    );
+}
+
+#[test]
+fn html_in_a_list_item_is_a_block() {
+    assert_eq!(
+        "*   <div>a</div>\n\n    <div>b</div>",
+        convert_faithful("<ul><li><div>a</div><div>b</div></li></ul>").unwrap()
+    );
+    assert_eq!(
+        "*   <br>\n\n    a",
+        convert_faithful("<ul><li><br><p>a</p></li></ul>").unwrap()
+    );
+    // Row 1 of "Lists" in `unsupported_html.md` wants two HTML blocks here, but
+    // `br` is a type 7 tag, so the run stays inline.
+    assert_eq!(
+        "*   <br><br>",
+        convert_faithful("<ul><li><br><br></li></ul>").unwrap()
+    );
+}
+
+/// A cell's contents are parsed as inline content, so no HTML block can open
+/// inside one.
+#[test]
+fn html_in_a_table_cell_is_a_raw_inline() {
+    assert_eq!(
+        "| h       |\n| ------- |\n| <br>*b* |",
+        convert_faithful(
+            "<table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td><br><em>b</em></td></tr></tbody></table>"
+        )
+        .unwrap()
+    );
+}
+
+#[test]
+fn html_in_an_inline_element_is_a_raw_inline() {
+    assert_eq!(
+        "a<span><br></span>b",
+        convert_faithful("<p>a<span><br></span>b</p>").unwrap()
+    );
+    assert_eq!(
+        "a<del><br></del>b",
+        convert_faithful("<p>a<del><br></del>b</p>").unwrap()
+    );
+    assert_eq!(
+        "a[<br>](u)b",
+        convert_faithful(r#"<p>a<a href="u"><br></a>b</p>"#).unwrap()
+    );
+}
+
+#[test]
+fn a_serialized_element_follows_its_context() {
+    assert_eq!(
+        r#"x <em foo="">y</em> z"#,
+        convert_faithful("<p>x <em foo>y</em> z</p>").unwrap()
+    );
+    assert_eq!(
+        r#"# <em foo="">y</em>"#,
+        convert_faithful("<h1><em foo>y</em></h1>").unwrap()
+    );
+    assert_eq!(
+        r#"*   <em foo="">y</em>"#,
+        convert_faithful("<ul><li><em foo>y</em></li></ul>").unwrap()
+    );
+}


### PR DESCRIPTION
Here's the first PR actually implementing parts of the spec. The following PRs continue this process.

Two rules from the "Translating HTML nodes" section of unsupported_html.md, which have to land together because each is wrong without the other.

An element written as HTML becomes an HTML block only where a block may begin *and* its tag opens one. A tag outside the type 1 and 6 lists would open a type 7 block, which cannot interrupt a paragraph and swallows every following line to the next blank one, so it is written as a raw HTML inline whatever the context.

A handler whose Markdown *is* a CommonMark block — a heading, paragraph, list, blockquote, rule, table, or a structural element handled by `handle_or_serialize_by_parent` — writes itself as a raw HTML inline when it finds itself in an inline context, since a block cannot be written where no block may begin. `serialize_if_extra_attrs_or_inline!` is `serialize_if_extra_attrs!` plus that test.

Without the second rule the first regresses `<h1><div><p>a</p></div></h1>`: the div stops being serialized whole and its `<p>` child is translated as Markdown, putting blank lines inside a heading.

`<pre>` in an inline context is still wrong, as a code block's content must stay literal; a later commit gives it the verbatim path it needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved faithful HTML-to-Markdown conversion based on context.
  - Elements that cannot begin a Markdown block in inline contexts are now preserved as raw inline HTML.
  - Block-level elements continue to use block formatting when appropriate.
  - Improved handling of attributes across headings, paragraphs, lists, tables, blockquotes, and other elements.
  - `<br>` elements are consistently preserved as raw inline HTML.

- **Tests**
  - Added coverage for document, paragraph, heading, list, table, blockquote, and inline contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->