### PR TITLE
Add: encode the line endings of a raw HTML inline.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -503,15 +503,26 @@ fn escape_pre_text_if_needed(text: Cow<'_, str>) -> Cow<'_, str> {
     }
 }
 
+/// CommonMark's [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks)
+/// type 1 tag list, the block-level half of [`BLOCK_ELEMENTS`] which ends at
+/// the line holding its closing tag rather than at a blank line.
+pub(crate) static TYPE_1_ELEMENTS: phf::Set<&'static str> = phf_set! {
+    "pre", "script", "style", "textarea",
+};
+
+pub(crate) fn is_type_1_element(tag: &str) -> bool {
+    TYPE_1_ELEMENTS.contains(tag)
+}
+
 /// The tags which frame their content as a block rather than an inline run.
 ///
 /// This is exactly CommonMark's
-/// [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks) type 1 list
-/// plus its type 6 list, and `element_util::try_serialize_element` relies on
-/// that: a tag outside both lists could only open a type 7 block, so it has to
-/// be written as a raw HTML inline instead. Keep this set in step with the spec
-/// — adding a tag here because it reads as block-like would silently change
-/// that classification.
+/// [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks)
+/// [type 1 list](TYPE_1_ELEMENTS) plus its type 6 list, and
+/// `element_util::try_serialize_element` relies on that: a tag outside both
+/// lists could only open a type 7 block, so it has to be written as a raw HTML
+/// inline instead. Keep this set in step with the spec — adding a tag here
+/// because it reads as block-like would silently change that classification.
 pub(crate) static BLOCK_ELEMENTS: phf::Set<&'static str> = phf_set! {
     "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption",
     "center", "col", "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt",

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -1,6 +1,6 @@
 use crate::{
     Context, Element,
-    dom_walker::is_block_element,
+    dom_walker::{is_block_element, is_type_1_element},
     element_handler::{HandlerResult, Handlers},
     node_util::parent_tag_name_equals,
     text_util::frame_as_block,
@@ -85,9 +85,9 @@ fn try_serialize_element(handlers: &dyn Handlers, element: &Element) -> io::Resu
     // context. See the "Translating HTML nodes" section of
     // `unsupported_html.md`.
     if element.context == Context::Block && is_block_element(element.tag) {
-        serialize_block_element(element, serialize_opts())
+        serialize_block_element(element)
     } else {
-        serialize_inline_element(handlers, element, serialize_opts())
+        serialize_inline_element(handlers, element)
     }
 }
 
@@ -98,17 +98,13 @@ fn serialize_opts() -> SerializeOpts {
     }
 }
 
-fn serialize_inline_element(
-    handlers: &dyn Handlers,
-    element: &Element,
-    options: SerializeOpts,
-) -> io::Result<String> {
+fn serialize_inline_element(handlers: &dyn Handlers, element: &Element) -> io::Result<String> {
     let NodeData::Element { name, attrs, .. } = &element.node.data else {
         return Err(io::Error::other("expected an element node"));
     };
 
     let mut bytes = Vec::new();
-    let mut serializer = HtmlSerializer::new(&mut bytes, options);
+    let mut serializer = HtmlSerializer::new(&mut bytes, serialize_opts());
     serializer.start_elem(
         name.clone(),
         attrs
@@ -126,20 +122,70 @@ fn serialize_inline_element(
                 .as_bytes(),
         )?;
     serializer.end_elem(name.clone())?;
+    let html = String::from_utf8(bytes).map_err(io::Error::other)?;
+    Ok(escape_inline_line_endings(html))
+}
+
+fn serialize_block_element(element: &Element) -> io::Result<String> {
+    let html = serialize_subtree(element)?;
+    // A type 6 HTML block ends at the next blank line, so a blank line written
+    // inside the serialized HTML has to be escaped to keep the block in one
+    // piece. A type 1 block ends at the line holding its closing tag instead,
+    // which leaves its line endings — blank ones included — free to stand as
+    // they are; escaping them would rewrite the script, style, or preformatted
+    // text itself. See the "Translating HTML nodes" section of
+    // `unsupported_html.md`.
+    let html = if is_type_1_element(element.tag) {
+        html
+    } else {
+        escape_html_block_blank_lines(html)
+    };
+    Ok(frame_as_block(&html))
+}
+
+fn serialize_subtree(element: &Element) -> io::Result<String> {
+    let mut bytes = Vec::new();
+    let handle = SerializableHandle::from(element.node.clone());
+    serialize(&mut bytes, &handle, serialize_opts())?;
     String::from_utf8(bytes).map_err(io::Error::other)
 }
 
-fn serialize_block_element(element: &Element, options: SerializeOpts) -> io::Result<String> {
-    let mut bytes = Vec::new();
-    let handle = SerializableHandle::from(element.node.clone());
-    serialize(&mut bytes, &handle, options)?;
-    let html = String::from_utf8(bytes).map_err(io::Error::other)?;
-    Ok(frame_as_block(&escape_html_block_blank_lines(&html)))
+// A raw HTML inline lives inside a leaf block, and every leaf block is ended by
+// a line ending it does not expect: a blank line ends the paragraph holding one,
+// a single line ending ends an ATX heading or a table row. Encode every line
+// ending, the safe over-generalization of the blank line rule described in
+// `unsupported_html.md`. A character reference in a raw HTML inline's tag or in
+// the CommonMark text it holds decodes back to the line ending it replaced.
+pub(crate) fn escape_inline_line_endings(html: String) -> String {
+    if !has_line_ending(&html) {
+        return html;
+    }
+
+    let mut result = String::with_capacity(html.len());
+    for ch in html.chars() {
+        match ch {
+            '\r' => result.push_str("&#13;"),
+            '\n' => result.push_str("&#10;"),
+            _ => result.push(ch),
+        }
+    }
+    result
+}
+
+/// Whether `html` holds anything for the escapes below to do: the fast path
+/// both of them share, and the one place the set of line endings they know
+/// about is written down.
+fn has_line_ending(html: &str) -> bool {
+    html.contains(['\r', '\n'])
 }
 
 // A blank line terminates a CommonMark HTML block. Encode every line ending
 // after the first so serialized block content remains in one HTML block.
-fn escape_html_block_blank_lines(html: &str) -> String {
+fn escape_html_block_blank_lines(html: String) -> String {
+    if !has_line_ending(&html) {
+        return html;
+    }
+
     let mut result = String::with_capacity(html.len());
     let mut chars = html.chars().peekable();
 
@@ -226,15 +272,23 @@ pub(crate) use serialize_if_extra_attrs_or_inline;
 
 #[cfg(test)]
 mod tests {
-    use super::escape_html_block_blank_lines;
+    use super::{escape_html_block_blank_lines, escape_inline_line_endings};
+
+    #[test]
+    fn escapes_every_line_ending_of_a_raw_inline() {
+        assert_eq!("ab", escape_inline_line_endings("ab".into()));
+        assert_eq!("a&#10;b", escape_inline_line_endings("a\nb".into()));
+        assert_eq!("a&#13;&#10;b", escape_inline_line_endings("a\r\nb".into()));
+        assert_eq!("a&#13;b", escape_inline_line_endings("a\rb".into()));
+    }
 
     #[test]
     fn escapes_blank_lines_for_each_line_ending_style() {
-        assert_eq!("a\n&#10;b", escape_html_block_blank_lines("a\n\nb"));
+        assert_eq!("a\n&#10;b", escape_html_block_blank_lines("a\n\nb".into()));
         assert_eq!(
             "a\r\n&#13;&#10;b",
-            escape_html_block_blank_lines("a\r\n\r\nb")
+            escape_html_block_blank_lines("a\r\n\r\nb".into())
         );
-        assert_eq!("a\r&#13;b", escape_html_block_blank_lines("a\r\rb"));
+        assert_eq!("a\r&#13;b", escape_html_block_blank_lines("a\r\rb".into()));
     }
 }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -180,6 +180,68 @@ fn html_in_an_inline_element_is_a_raw_inline() {
     );
 }
 
+/// A line ending in a raw HTML inline ends the leaf block holding it: a blank
+/// line ends a paragraph, and a single line ending ends an ATX heading or a
+/// table row. Each is therefore written as a character reference.
+#[test]
+fn a_raw_inline_escapes_its_line_endings() {
+    assert_eq!(
+        r#"a<em foo="1&#10;&#10;2">y</em>b"#,
+        convert_faithful("<p>a<em foo=\"1\n\n2\">y</em>b</p>").unwrap()
+    );
+    assert_eq!(
+        "# <pre>x&#10;y</pre>",
+        convert_faithful("<h1><pre>x\ny</pre></h1>").unwrap()
+    );
+    // The parser folds a literal CRLF into a line feed, so the carriage return
+    // has to arrive as a character reference to survive.
+    assert_eq!(
+        "# <pre>x&#13;&#10;y</pre>",
+        convert_faithful("<h1><pre>x&#13;&#10;y</pre></h1>").unwrap()
+    );
+    assert_eq!(
+        concat!(
+            "| h                        |\n",
+            "| ------------------------ |\n",
+            "| <em foo=\"1&#10;2\">y</em> |"
+        ),
+        convert_faithful(
+            "<table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td><em foo=\"1\n2\">y</em></td></tr></tbody></table>"
+        )
+        .unwrap()
+    );
+    // Only a blank line ends a type 6 HTML block, so one keeps the rest of its
+    // line structure.
+    assert_eq!(
+        "<div>a\n&#10;b</div>",
+        convert_faithful("<div>a\n\nb</div>").unwrap()
+    );
+}
+
+/// A type 1 HTML block ends at its closing tag rather than at a blank line, so
+/// escaping a blank line inside one would needlessly rewrite the script, style,
+/// or preformatted text itself.
+#[test]
+fn a_type_1_block_keeps_its_blank_lines() {
+    assert_eq!(
+        "<script>a\n\nb</script>",
+        convert_faithful("<script>a\n\nb</script>").unwrap()
+    );
+    assert_eq!(
+        "<style>a\n\nb</style>",
+        convert_faithful("<style>a\n\nb</style>").unwrap()
+    );
+    assert_eq!(
+        "<pre>a\n\nb</pre>",
+        convert_faithful("<pre>a\n\nb</pre>").unwrap()
+    );
+    assert_eq!(
+        "<textarea>a\n\nb</textarea>",
+        convert_faithful("<textarea>a\n\nb</textarea>").unwrap()
+    );
+}
+
 #[test]
 fn a_serialized_element_follows_its_context() {
     assert_eq!(


### PR DESCRIPTION
A raw HTML inline sits inside a leaf block, and a line ending ends the block holding it: a blank line ends a paragraph, and a single line ending ends an ATX heading or a table row, truncating the element. Every line ending in one is therefore written as `&#13;`/`&#10;`, which the CommonMark parser decodes back to the line ending it replaced. This is the safe over-generalization of the blank-line rule in unsupported_html.md, which needs it only for a blank line.

An HTML block gains the converse exemption. `escape_html_block_blank_lines` exists because a type 6 block ends at a blank line, but a type 1 block — `pre`, `script`, `style`, `textarea` — ends at the line holding its closing tag, so its blank lines can stand as they are; escaping them would rewrite the script, stylesheet, or preformatted text itself. `TYPE_1_ELEMENTS` names that half of `BLOCK_ELEMENTS`.

Both escapes take their argument by value and return it untouched when it holds no line ending, which is the common case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of raw HTML line endings during rendering.
  * Preserved literal blank lines in `script`, `style`, `pre`, and `textarea` blocks.
  * Escaped line endings in inline raw HTML to prevent unintended document structure changes.

* **Tests**
  * Added coverage for raw inline HTML line endings and type-specific block behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->