### PR TITLE
Add: serialize raw text elements and inline code blocks verbatim.

### DIFF
--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer, TraversalScope, serialize};
 use markup5ever_rcdom::{NodeData, SerializableHandle};
+use phf::phf_set;
 use std::io::{self, Write};
 
 /// Returns from the enclosing handler with `content` as the element's HTML,
@@ -86,9 +87,40 @@ fn try_serialize_element(handlers: &dyn Handlers, element: &Element) -> io::Resu
     // `unsupported_html.md`.
     if element.context == Context::Block && is_block_element(element.tag) {
         serialize_block_element(element)
+    } else if is_raw_text_element(element.tag) {
+        // What a raw text element holds is literal characters, not markup, so
+        // translating it the way `serialize_inline_element` does would rewrite
+        // the text itself.
+        serialize_inline_verbatim(element)
     } else {
         serialize_inline_element(handlers, element)
     }
+}
+
+/// The tags whose content an HTML parser reads as raw text: no markup, and no
+/// character references either. That second half is what rules out translating
+/// them; see [`serialize_inline_verbatim`]. The RCDATA elements `textarea` and
+/// `title` are deliberately absent — an HTML parser does decode references
+/// inside those, so they take the ordinary raw HTML inline path, where the
+/// Markdown their content holds is escaped along with it.
+///
+/// **In an inline context that path does not meet the newline encoding the
+/// "Translating HTML nodes" table of `unsupported_html.md` asks of these two
+/// tags** — type 1 for `textarea`, type 6 for `title`. Walking the content as
+/// CommonMark is what escapes the Markdown in it, and that same walk compresses
+/// a line ending to a space before anything can encode it:
+/// `<h1><textarea>a⏎b</textarea></h1>` is written `# <textarea>a b</textarea>`,
+/// not `# <textarea>a&#10;b</textarea>`. Keeping both halves would need a walk
+/// which preserves whitespace *and* escapes Markdown specials, and neither mode
+/// the walker has does both — `is_pre_element` content preserves whitespace but
+/// goes out unescaped. The line ending is what is given up, because giving up
+/// the escaping instead would let `a*b*c` in a textarea come back as emphasis.
+static RAW_TEXT_ELEMENTS: phf::Set<&'static str> = phf_set! {
+    "script", "style",
+};
+
+fn is_raw_text_element(tag: &str) -> bool {
+    RAW_TEXT_ELEMENTS.contains(tag)
 }
 
 fn serialize_opts() -> SerializeOpts {
@@ -141,6 +173,34 @@ fn serialize_block_element(element: &Element) -> io::Result<String> {
         escape_html_block_blank_lines(html)
     };
     Ok(frame_as_block(&html))
+}
+
+/// [`serialize_inline_verbatim`] for callers outside this module.
+pub(crate) fn serialize_element_verbatim(element: &Element) -> String {
+    serialize_inline_verbatim(element).unwrap_or_else(|error| error.to_string())
+}
+
+/// Serializes `element` and everything it holds as HTML, translating none of
+/// it. Unlike a raw HTML inline, whose content is still translated, the content
+/// of a code block or a raw text element is literal text: no CommonMark
+/// encoding survives there. The result is a raw HTML inline, so its line
+/// endings are escaped as well.
+///
+/// A line ending does survive this: only the tags of a raw HTML inline are
+/// HTML, so a CommonMark parser reads what sits between them as text and
+/// decodes the `&#13;`/`&#10;` there before any HTML parser sees a `<script>`
+/// element.
+///
+/// **Limitation:** that same fact costs the content its escaping. Serializing
+/// it leaves any Markdown special it holds bare, and the CommonMark parser
+/// reading it back takes that special as Markdown — `a*b*c` in a script comes
+/// back as `a<em>b</em>c`. Escaping the content instead would need an escape
+/// which survives an HTML parser, and a character reference is not one: inside
+/// a raw text element it stays those five or six characters. Representing this
+/// faithfully needs the containing block serialized instead, which is the
+/// "Special case" section of `unsupported_html.md`.
+fn serialize_inline_verbatim(element: &Element) -> io::Result<String> {
+    serialize_subtree(element).map(escape_inline_line_endings)
 }
 
 fn serialize_subtree(element: &Element) -> io::Result<String> {

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -1,9 +1,11 @@
 use crate::{
-    Element,
-    element_handler::element_util::serialize_if_extra_attrs,
+    Context, Element,
     element_handler::{
         HandlerResult, Handlers,
-        element_util::{serialize_element, serialize_element_result},
+        element_util::{
+            serialize_element, serialize_element_result, serialize_element_verbatim,
+            serialize_if_extra_attrs, serialize_when_faithful,
+        },
     },
     node_util::get_node_tag_name,
     options::TranslationMode,
@@ -11,6 +13,14 @@ use crate::{
 };
 
 pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
+    // A code block is a CommonMark block, so it needs a block context. In an
+    // inline context it is written as a raw HTML inline instead — one holding
+    // no CommonMark, since a code block's content is literal text.
+    serialize_when_faithful!(
+        handlers,
+        element.context == Context::Inline,
+        serialize_element_verbatim(&element)
+    );
     serialize_if_extra_attrs!(handlers, element, 0);
     // The only faithful translation for this is from
     // `<pre><code>blah</code></pre>` to a code block. So, check that this node
@@ -31,11 +41,11 @@ pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<H
     if handlers.options().translation_mode == TranslationMode::Pure || is_simple_code_block {
         let result = handlers.walk_children(element.node, element.context);
 
-        if handlers.options().translation_mode == TranslationMode::Faithful
-            && !result.markdown_translated
-        {
-            return Some(HandlerResult::html(serialize_element(handlers, &element)));
-        }
+        serialize_when_faithful!(
+            handlers,
+            !result.markdown_translated,
+            serialize_element(handlers, &element)
+        );
 
         Some(frame_as_block(&result.content).into())
     } else {

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -68,7 +68,11 @@ fn a_commonmark_block_in_an_inline_context_is_a_raw_inline() {
     );
     assert_eq!("# <hr>", convert_faithful("<h1><hr></h1>").unwrap());
     // Only the tags of a raw HTML inline are HTML; what it holds is still
-    // translated.
+    // translated, except in a code block, whose content is literal text.
+    assert_eq!(
+        "# <pre><code>a</code></pre>",
+        convert_faithful("<h1><pre><code>a</code></pre></h1>").unwrap()
+    );
     assert_eq!(
         "# <table><thead><tr><th>h</th></tr></thead><tbody><tr><td>a</td></tr></tbody></table>",
         convert_faithful(
@@ -180,6 +184,85 @@ fn html_in_an_inline_element_is_a_raw_inline() {
     );
 }
 
+/// The content of a code span or code block is literal text, so no encoding of
+/// a break survives there.
+#[test]
+fn html_in_code_is_a_raw_inline() {
+    assert_eq!(
+        "a<code>x<br>y</code>b",
+        convert_faithful("<p>a<code>x<br>y</code>b</p>").unwrap()
+    );
+    assert_eq!(
+        "<pre><code>a<br>b</code></pre>",
+        convert_faithful("<pre><code>a<br>b</code></pre>").unwrap()
+    );
+    // An untranslatable attribute on the `<pre>` is no reason to start
+    // translating content which must stay literal.
+    assert_eq!(
+        "# <pre><b>a</b></pre>",
+        convert_faithful("<h1><pre><b>a</b></pre></h1>").unwrap()
+    );
+    assert_eq!(
+        r#"# <pre class="x"><b>a</b></pre>"#,
+        convert_faithful(r#"<h1><pre class="x"><b>a</b></pre></h1>"#).unwrap()
+    );
+}
+
+/// A raw text element holds literal characters rather than markup, so it is
+/// serialized whole: Markdown escaping or whitespace collapsing there would
+/// rewrite the script, style, or textarea itself.
+#[test]
+fn a_raw_text_element_is_serialized_verbatim() {
+    assert_eq!(
+        "# <script>a*b_c[d]</script>",
+        convert_faithful("<h1><script>a*b_c[d]</script></h1>").unwrap()
+    );
+    assert_eq!(
+        "# <script>if(a<b){}</script>",
+        convert_faithful("<h1><script>if(a<b){}</script></h1>").unwrap()
+    );
+    assert_eq!(
+        "x<script>a*b</script>y",
+        convert_faithful("<p>x<script>a*b</script>y</p>").unwrap()
+    );
+    assert_eq!(
+        "<script>a*b\nc</script>",
+        convert_faithful("<script>a*b\nc</script>").unwrap()
+    );
+    // The escaped line ending survives the trip back: a CommonMark parser
+    // decodes the reference while producing the raw HTML inline.
+    assert_eq!(
+        "# <script>a&#10;b</script>",
+        convert_faithful("<h1><script>a\nb</script></h1>").unwrap()
+    );
+}
+
+/// `textarea` and `title` hold no markup either, but an HTML parser decodes a
+/// character reference inside one. That decoding is the reason raw text
+/// elements must be serialized verbatim, so these two take the ordinary raw
+/// HTML inline path instead.
+#[test]
+fn an_rcdata_element_is_translated() {
+    assert_eq!(
+        r"# <textarea>a\*b\*c</textarea>",
+        convert_faithful("<h1><textarea>a*b*c</textarea></h1>").unwrap()
+    );
+    assert_eq!(
+        r"# <title>a\*b\*c</title>",
+        convert_faithful("<h1><title>a*b*c</title></h1>").unwrap()
+    );
+    // The walk compresses a line ending to a space rather than escaping it, so
+    // that is the half this path loses.
+    assert_eq!(
+        "# <textarea>a b</textarea>",
+        convert_faithful("<h1><textarea>a\nb</textarea></h1>").unwrap()
+    );
+    assert_eq!(
+        "<textarea>a*b\nc</textarea>",
+        convert_faithful("<textarea>a*b\nc</textarea>").unwrap()
+    );
+}
+
 /// A line ending in a raw HTML inline ends the leaf block holding it: a blank
 /// line ends a paragraph, and a single line ending ends an ATX heading or a
 /// table row. Each is therefore written as a character reference.
@@ -239,6 +322,10 @@ fn a_type_1_block_keeps_its_blank_lines() {
     assert_eq!(
         "<textarea>a\n\nb</textarea>",
         convert_faithful("<textarea>a\n\nb</textarea>").unwrap()
+    );
+    assert_eq!(
+        "# <script>a&#10;&#10;b</script>",
+        convert_faithful("<h1><script>a\n\nb</script></h1>").unwrap()
     );
 }
 


### PR DESCRIPTION
An HTML parser reads the content of `<script>` and `<style>` as raw text: no markup, and no character references either. Walking that content as CommonMark, which is what the raw HTML inline path does, would rewrite the script or stylesheet itself, so these are serialized whole instead.

A `<pre>` in an inline context needs the same treatment for the same reason: a code block holds literal text, so the previous commit left it translating its own content into Markdown.

`textarea` and `title` are deliberately not in the raw text list. An HTML parser does decode a character reference inside those, so they keep the ordinary path, which escapes the Markdown their content holds. Both choices give up one half of the "Translating HTML nodes" table: a raw text element keeps its line ending and loses the escaping of Markdown specials, an RCDATA element the reverse. The comments on `RAW_TEXT_ELEMENTS` and `serialize_inline_verbatim` record which half each gives up and why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the literal content and line endings of `script` and `style` elements during conversion.
  * Ensured code blocks and raw-text elements remain verbatim in inline contexts.
  * Improved handling of multiline raw-text content within headings.
  * Continued translating `textarea` and `title` content with appropriate escaping. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->