### PR TITLE
Fix spec errors, along with partial spec implementation.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -3,13 +3,16 @@ use markup5ever_rcdom::{Node, NodeData};
 use phf::phf_set;
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
-use crate::{Context, element_handler::ElementHandlers};
+use crate::{
+    Context,
+    element_handler::{ElementHandlers, element_util::escape_inline_line_endings},
+};
 
 use super::{
     options::TranslationMode,
     text_util::{
-        TrimDocumentWhitespace, compress_whitespace, index_of_markdown_ordered_item_dot,
-        is_markdown_atx_heading,
+        TrimDocumentWhitespace, compress_whitespace, concat_strings, frame_as_block,
+        index_of_markdown_ordered_item_dot, is_markdown_atx_heading,
     },
 };
 
@@ -61,14 +64,37 @@ pub(crate) fn walk_node(
         ),
         NodeData::Comment { contents } => {
             if handlers.options.translation_mode == TranslationMode::Faithful {
-                output.push_str("<!--");
-                output.push_str(contents);
-                output.push_str("-->");
+                walk_comment(contents, output, state);
             }
             true
         }
         NodeData::Doctype { .. } => true,
         NodeData::ProcessingInstruction { .. } => true,
+    }
+}
+
+/// A comment is an
+/// [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks) of type 2,
+/// which ends at its own `-->` rather than at a blank line: in a block context
+/// it is framed as a block and its line endings are left as they are. In an
+/// inline context it is a raw HTML inline instead, and its line endings are
+/// escaped.
+///
+/// **That escape is an incorrect workaround.** The "Translating HTML nodes"
+/// table of `unsupported_html.md` gives a type 2-5 node in an inline context a
+/// newline encoding of `None`, because encoding works only where the HTML
+/// parser decodes character references and it decodes none inside a comment:
+/// the `&#10;` written here comes back as those five characters rather than as
+/// the line ending it replaced. It is kept because the conforming alternative
+/// is worse — a bare line ending ends the leaf block holding the comment,
+/// splitting a paragraph in two or cutting an ATX heading or a table row short.
+/// Representing this faithfully needs the containing block serialized instead,
+/// which is the "Special case" that document sets aside.
+fn walk_comment(contents: &str, output: &mut String, state: WalkState) {
+    let html = concat_strings!("<!--", contents, "-->");
+    match state.context {
+        Context::Block => append_normalized_content(output, frame_as_block(&html), state.is_pre),
+        Context::Inline => output.push_str(&escape_inline_line_endings(html)),
     }
 }
 

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -145,7 +145,18 @@ pub(crate) fn frame_as_block(content: &str) -> String {
 /// Normalizes an `alt` or `title` attribute value for Markdown: each line is
 /// trimmed of document whitespace, blank lines are dropped, every `"` is
 /// escaped so the value can sit inside a quoted title, and what is left is
-/// joined with a newline.
+/// joined with `&#10;`.
+///
+/// The join is a character reference rather than the line ending it replaces
+/// because the value ends up inside a CommonMark inline — a link destination's
+/// title, or the label an image takes its alt text from — and a line ending
+/// there ends the leaf block holding it, truncating an ATX heading or a table
+/// row. CommonMark recognizes character references in both places, so `&#10;`
+/// decodes back to the line ending it replaced; this is the same encoding
+/// [`escape_inline_line_endings`] applies to a raw HTML inline.
+///
+/// [`escape_inline_line_endings`]:
+///     crate::element_handler::element_util::escape_inline_line_endings
 pub(crate) fn normalize_title(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     for line in text.lines() {
@@ -154,11 +165,15 @@ pub(crate) fn normalize_title(text: &str) -> String {
             continue;
         }
         if !result.is_empty() {
-            result.push('\n');
+            result.push_str("&#10;");
         }
         for ch in line.chars() {
             match ch {
                 '"' => result.push_str("\\\""),
+                // `lines()` splits on a line feed, so a lone carriage return —
+                // which an attribute value can still hold, written as `&#13;` —
+                // reaches here intact and needs the same encoding.
+                '\r' => result.push_str("&#13;"),
                 _ => result.push(ch),
             }
         }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -377,6 +377,28 @@ fn a_title_escapes_its_line_endings() {
     );
 }
 
+/// A comment is a type 2 HTML block, which likewise ends at its own `-->`.
+#[test]
+fn a_comment_follows_its_context() {
+    assert_eq!("<!--a\n\nb-->", convert_faithful("<!--a\n\nb-->").unwrap());
+    assert_eq!(
+        "<div>a</div>\n\n<!--c-->\n\n<div>b</div>",
+        convert_faithful("<div>a</div><!--c--><div>b</div>").unwrap()
+    );
+    assert_eq!(
+        "> <!--c-->",
+        convert_faithful("<blockquote><!--c--></blockquote>").unwrap()
+    );
+    assert_eq!(
+        "# x<!--a&#10;b-->y",
+        convert_faithful("<h1>x<!--a\nb-->y</h1>").unwrap()
+    );
+    assert_eq!(
+        "x<!--a&#10;&#10;b-->y",
+        convert_faithful("<p>x<!--a\n\nb-->y</p>").unwrap()
+    );
+}
+
 #[test]
 fn a_serialized_element_follows_its_context() {
     assert_eq!(

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -329,6 +329,54 @@ fn a_type_1_block_keeps_its_blank_lines() {
     );
 }
 
+/// A link title and an image's alt text are inline content, and a line ending
+/// there ends the leaf block holding it just as one in a raw HTML inline does:
+/// written literally, `# [t](u "a⏎b")` is the heading `[t](u "a` followed by
+/// the paragraph `b")`. CommonMark recognizes character references in both, so
+/// each line ending is encoded instead.
+#[test]
+fn a_title_escapes_its_line_endings() {
+    assert_eq!(
+        r#"# [t](u "a&#10;b")"#,
+        convert_faithful("<h1><a href=\"u\" title=\"a\nb\">t</a></h1>").unwrap()
+    );
+    assert_eq!(
+        r#"# ![a&#10;b](i "c&#10;d")"#,
+        convert_faithful("<h1><img src=\"i\" alt=\"a\nb\" title=\"c\nd\"></h1>").unwrap()
+    );
+    // A blank line is dropped rather than encoded: the lines around it are
+    // joined by the one reference the surviving line break needs.
+    assert_eq!(
+        r#"[t](u "a&#10;b")"#,
+        convert_faithful("<p><a href=\"u\" title=\"a\n\nb\">t</a></p>").unwrap()
+    );
+    // A carriage return reaches the title only as a character reference, the
+    // parser having folded any literal CRLF into a line feed. `lines()` splits
+    // a CRLF, so that pair normalizes to the one reference a line break needs...
+    assert_eq!(
+        r#"# [t](u "a&#10;b")"#,
+        convert_faithful("<h1><a href=\"u\" title=\"a&#13;&#10;b\">t</a></h1>").unwrap()
+    );
+    // ...while a lone carriage return is no line break to `lines()` and so is
+    // encoded where it stands.
+    assert_eq!(
+        r#"# [t](u "a&#13;b")"#,
+        convert_faithful("<h1><a href=\"u\" title=\"a&#13;b\">t</a></h1>").unwrap()
+    );
+    assert_eq!(
+        concat!(
+            "| h                |\n",
+            "| ---------------- |\n",
+            "| [t](u \"a&#10;b\") |"
+        ),
+        convert_faithful(
+            "<table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td><a href=\"u\" title=\"a\nb\">t</a></td></tr></tbody></table>"
+        )
+        .unwrap()
+    );
+}
+
 #[test]
 fn a_serialized_element_follows_its_context() {
     assert_eq!(

--- a/tests/html/turndown_test_index.html
+++ b/tests/html/turndown_test_index.html
@@ -181,24 +181,21 @@ after the break</pre>
 <div class="case" data-name="img with a new line in alt">
   <div class="input"><img src="logo.png" alt="img with
     alt"></div>
-  <pre class="expected">![img with
-alt](logo.png)</pre>
+  <pre class="expected">![img with<!-- line feed -->alt](logo.png)</pre>
 </div>
 
 <div class="case" data-name="img with more than one new line in alt">
   <div class="input"><img src="logo.png" alt="img with
     
     alt"></div>
-  <pre class="expected">![img with
-alt](logo.png)</pre>
+  <pre class="expected">![img with<!-- line feed -->alt](logo.png)</pre>
 </div>
 
 <div class="case" data-name="img with new lines in title">
   <div class="input"><img src="logo.png" title="the
     
     title"></div>
-  <pre class="expected">![](logo.png "the
-title")</pre>
+  <pre class="expected">![](logo.png "the<!-- line feed -->title")</pre>
 </div>
 
 <div class="case" data-name="a">
@@ -215,8 +212,7 @@ title")</pre>
   <div class="input"><a href="http://example.com" title="Title for
     
     link">An anchor</a></div>
-  <pre class="expected">[An anchor](http://example.com "Title for
-link")</pre>
+  <pre class="expected">[An anchor](http://example.com "Title for<!-- line feed -->link")</pre>
 </div>
 
 <div class="case" data-name="a with quotes in title">

--- a/tests/turndown_cases_tests.rs
+++ b/tests/turndown_cases_tests.rs
@@ -153,7 +153,11 @@ fn run_cases() {
                 .replace("&gt;", ">")
                 .replace("&nbsp;", "\u{a0}")
                 // For case: list-like text with non-breaking spaces
-                .replace("<!-- hard break -->", ""),
+                .replace("<!-- hard break -->", "")
+                // For the cases with a new line in an `alt` or `title`, which
+                // expect the character reference for one. Writing the reference
+                // out would only have it decoded when the index is parsed.
+                .replace("<!-- line feed -->", "&#10;"),
             md,
             "Failed on test case '{}' ({}/{})",
             case.name,

--- a/unsupported_html.md
+++ b/unsupported_html.md
@@ -64,45 +64,75 @@ Leaf blocks, which are headings (`<h1>`-`<h6>`), paragraphs (`<p>`), and tables
 which are a blockquote (`<blockquote>`) and a list item (`<li>`), begin a block
 context. No other HTML element can affect the context. This context passed down
 by the DOM walker then enables an HTML node to examine the current context to be
-correctly translated. Note that the contents of code blocks are treated as
-literal text, making them neither an inline nor a block context. Since these
-cannot contain HTML nodes, they are exempt from the following logic.
+correctly translated. Note that the contents of CommonMark code blocks are
+treated as literal text, making them neither an inline nor a block context.
+Since CommonMark code blocks cannot contain HTML nodes, they are exempt from the
+following logic.
 
-| HTML node                     | Context | Newline encoding | CommonMark translation |
-| ----------------------------- | ------- | ---------------- | ---------------------- |
-| Type 1-5                      | Block   | None             | HTML block             |
-| Type 1                        | Inline  | Newlines         | Raw HTML inline        |
-| Type 2-5, with blank lines    | Inline  | None             | Special case           |
-| Type 2-5, without blank lines | Inline  | None             | Raw HTML inline        |
-| Type 6                        | Block   | Blank lines      | HTML block             |
-| Type 6                        | Inline  | Newlines         | Raw HTML inline        |
-| Type 7                        | Any     | Newlines         | Raw HTML inline        |
+| HTML node | Context | Newline encoding  | CommonMark translation |
+| --------- | ------- | ----------------- | ---------------------- |
+| Type 1-5  | Block   | None              | HTML block             |
+| Type 1    | Inline  | Newlines          | Raw HTML inline        |
+| Type 2-5  | Inline  | Newlines ⇒ spaces | Raw HTML inline        |
+| Type 6    | Block   | Blank lines       | HTML block             |
+| Type 6    | Inline  | Newlines          | Raw HTML inline        |
+| Type 7    | Any     | Newlines          | Raw HTML inline        |
 
 Newline encoding consists of replacing CR/LF characters with `&#13;`/`&#10;`.
-Blank lines are defined by
+Blank line encoding consists of newline encoding of blank lines, where blank
+lines are defined by
 [section 2.1 of the CommonMark spec](https://spec.commonmark.org/0.31.2/#characters-and-lines).
-Encoding works exactly when the HTML parser decodes character references at that
-position; the following special cases flow from this understanding.
+Newlines ⇒ spaces consists of replacing newlines with a space. CommonMark HTML
+blocks and type 2-5 raw HTML inlines need no additional encoding, while the
+contents of type 1 `<pre>`/`<textarea>` and type 6-7 as raw HTML inlines must be
+CommonMark escaped (see `dom_walker::escape_if_needed()`).
 
-**Special case**: the containing CommonMark block must be translated as an HTML
-block while also translating the special case type 2-5 content as an HTML block
-then appending the remaining HTML contents to it without an intervening newline;
-`<h1>a<!--b⏎⏎c-->d</h1>` becomes `<h1>a⏎⏎<!--b⏎⏎c-->d</h1>` (which is a slightly
-lossy translation). Due to this complexity, the current implementation is
-unspecified for simplicity.
+Type 1 content placed inline works for `<pre>` and `<textarea>`: newlines can be
+encoded as HTML character references, and always-encoded characters `"`, `&`,
+`<`, or `>` are interpreted by the HTML parser. For `<script>` and `<style>`,
+newlines can still be encoded, since they are interpreted by the CommonMark
+parser; however, the always-encoded characters are not interpreted by the HTML
+parser inside these tags. This requires a tradeoff: for simplicity this type 1
+content leaves the always-encoded characters in `<script>`/`<style>` tags,
+causing them to be mis-translated; the alternative of emitting this content as
+an HTML block would mis-translate this content placed in CommonMark blocks that
+cannot contain a newline (headings and tables). (A more complex, higher-fidelity
+result comes from translating the containing CommonMark block to HTML while also
+translating the type 1 content as an HTML block then appending the remaining
+HTML contents to it without an intervening newline;
+`<h1>a<script>"&<⏎⏎>"</script></h1>` becomes
+`<h1>a⏎⏎<script>"&<⏎⏎>"</script></h1>`, which is a slightly lossy translation.)
 
-**Special case**: If (`<script>`, `<style>` or type 2-5 blocks) containing blank
-lines are nested inside a type 6 block, the naive translated result is
-incorrect. The correct result would be placing a blank line after the type 6
-block to start another block, following the approach of previous special case.
+Type 2-5 content placed inline face other difficulties. Newlines cannot be
+encoded, since the CommonMark parser doesn't interpret entities inside this type
+of raw HTML inline. For simplicity, newlines are replaced with spaces, a lossy
+translation. (A more complex, higher-fidelity result comes from translating the
+containing CommonMark block to HTML while also translating the type 2-5 content
+as an HTML block then appending the remaining HTML contents to it without an
+intervening newline; `<h1>a<!--b⏎⏎c-->d</h1>` becomes
+`<h1>a⏎⏎<!--b⏎⏎c-->d</h1>`, which is a slightly lossy translation.)
+
+Encoding works exactly when the parser reading that position decodes character
+references there: the CommonMark parser in the text of a raw HTML inline, the
+HTML parser in the data and attribute values of an HTML block. It works nowhere
+else — inside a comment, a CDATA section, a declaration, or a raw text element
+the reference stays as the literal characters composing it. The following
+special cases flow from this.
+
+**Special case**: If a type 1 `<script>`, `<style>` or a type 2-5 block
+containing blank lines is nested inside a type 6 block, the naive translated
+result is incorrect. The correct result would be placing a blank line before the
+next type 1-6 block to start another block. Likewise, nesting a type 1-5 block
+inside a another type 1 block fails when the inner block contains any type 1
+termination condition followed by newline lines: `<pre><style></style>⏎a</pre>`.
 Due to this complexity, the current implementation is unspecified for
 simplicity.
 
 **Special case**: Content in `<iframe>`, `<xmp>`, `<noscript>` (scripting
-enabled), `<noembed>`, `<noframes>`, and `<plaintext>` tags all come back from
-the HTML5ever tokenizer as literal characters, meaning encoding cannot be used
-to handle newlines. The implementation for these unusual cases is unspecified
-for simplicity.
+enabled), `<noembed>`, `<noframes>`, and `<plaintext>` tags comes back from the
+html5ever tokenizer as literal characters, meaning encoding cannot be used to
+handle newlines. The implementation for these unusual cases is unspecified for
+simplicity.
 
 The type 7 choice of always translating to a raw HTML inline is a tradeoff: it
 provides more natural behavior inside tight lists and when encountering text
@@ -225,12 +255,11 @@ At the document root
 | `<br>` after a block       | `<p>a</p><br>`               | `a⏎⏎<br>`                    |
 | `<br>`s-only `<div>`       | `<div><br><br>...<br></div>` | `<div><br><br>...<br></div>` |
 
-Note that rows 1 and 5 round-trip exactly, while the remaining rows wrap the
-result in a paragraph per the discussion in the translating HTML nodes section.
-The `<div>` row needs no special case at all: `div` *is* a block-level tag name,
-so the whole element is an HTML block of
-[type 6](https://spec.commonmark.org/0.31.2/#html-blocks) and round-trips
-verbatim, however many `<br>`s it holds.
+Note that row 2 wraps the result in a paragraph per the discussion in the
+translating HTML nodes section, a lossy translation. The `<div>` row needs no
+special case at all: `div` *is* a block-level tag name, so the whole element is
+an HTML block of [type 6](https://spec.commonmark.org/0.31.2/#html-blocks) and
+round-trips verbatim, however many `<br>`s it holds.
 
 Headings
 --------
@@ -274,9 +303,9 @@ Paragraphs
 | `<br>` before an image               | `<p><br><img src="i"></p>` | `<br>![](i)`      |
 | `<br>` after an image                | `<p><img src="i"><br></p>` | `![](i)<br>`      |
 
-The first row is the analysis section's rule that a paragraph writing out as a
-single complete tag must be serialized: a bare `<br>` re-opens as an HTML block,
-and the `<p>` around it would be lost.
+The first row is the special case for paragraph section's rule that a paragraph
+writing out as a single complete tag must be serialized: a bare `<br>` re-opens
+as an HTML block, and the `<p>` around it would be lost.
 
 Two or more `<br>`s need nothing of the sort. The second tag keeps the line from
 being type 7, so the plain encoding is already an ordinary paragraph and
@@ -313,8 +342,8 @@ width. Table heading behavior is identical to body-cell behavior. In the
 
 A cell's contents are parsed as inline content, so no HTML block can open inside
 one and the rule in the analysis section never applies. Any cell contents which
-require a newline (such as an HTML comment with blank lines) forces the entire
-table to be serialized as HTML.
+require a newline (such as a list) force the entire table to be serialized as
+HTML.
 
 | Description                       | HTML in                    | Faithful expected               |
 | --------------------------------- | -------------------------- | ------------------------------- |
@@ -333,8 +362,9 @@ Lists
 | `<br>`-only paragraph (one `<br>`)   | `<ul><li><p><br></p></li></ul>`            | `*␣␣␣<p><br></p>`     |
 | `<br>`s-only paragraph (two or more) | `<ul><li><p><br><br>...<br></p></li></ul>` | `*␣␣␣<br><br>...<br>` |
 
-Row 4 results from the special case section above: like a blockquote, a list
-item's marker is stripped like a `>`, so a bare tag re-opens as an HTML block.
+Row 4 results from the special case for paragraphs section above: like a
+blockquote, a list item's marker is stripped like a `>`, so a bare tag re-opens
+as an HTML block.
 
 Note that the last row of this table produces the desired HTML only in a loose
 list; in a tight list, it produces the HTML for row 1. The algorithm below uses
@@ -365,8 +395,7 @@ Notes:
   [blockquote](https://spec.commonmark.org/0.31.2/#block-quotes), an
   [ATX heading](https://spec.commonmark.org/0.31.2/#atx-headings), a
   [fenced code block](https://spec.commonmark.org/0.31.2/#fenced-code-blocks), a
-  [thematic break](https://spec.commonmark.org/0.31.2/#thematic-breaks), a
-  [GFM table](https://github.github.com/gfm/#tables-extension-), or an
+  [thematic break](https://spec.commonmark.org/0.31.2/#thematic-breaks), or an
   [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks) of types 1-6 —
   then omit the blank line which separates them except in approach 1.2.1 below.
 * A CommonMark list of one item holding one block cannot contain a blank line,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML-to-Markdown conversion for comments in headings, paragraphs, blockquotes, and document roots.
  * Link titles, image titles, and alt text now preserve line endings safely using character references.
  * Blank lines in titles and alt text are handled consistently, with CRLF sequences normalized correctly.

* **Documentation**
  * Updated HTML translation guidance and special-case behavior for inline and block content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->