### PR TITLE
Add: round-trip tests through a CommonMark parser.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -263,9 +263,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "fastrand"
@@ -333,7 +333,10 @@ dependencies = [
  "markup5ever_rcdom",
  "phf 0.14.0",
  "pretty_assertions",
+ "pulldown-cmark",
  "scraper",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -398,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "markup5ever"
@@ -647,6 +650,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,7 +838,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -861,9 +883,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "stable_deref_trait"
@@ -909,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -936,6 +958,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 pretty_assertions = "1.4.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+pulldown-cmark = "0.13.4"
 
 [[bench]]
 name = "convert_bench"

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -189,7 +189,8 @@ pub(crate) fn serialize_element_verbatim(element: &Element) -> String {
 /// A line ending does survive this: only the tags of a raw HTML inline are
 /// HTML, so a CommonMark parser reads what sits between them as text and
 /// decodes the `&#13;`/`&#10;` there before any HTML parser sees a `<script>`
-/// element.
+/// element. `round_trip_in_an_inline_context` in `tests/basic_tests.rs` shows
+/// the trip.
 ///
 /// **Limitation:** that same fact costs the content its escaping. Serializing
 /// it leaves any Markdown special it holds bare, and the CommonMark parser

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, thread::JoinHandle};
 
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use pulldown_cmark::{Options as CommonMarkOptions, Parser};
 
 use htmd::{
     Element, HtmlToMarkdown,
@@ -705,4 +706,135 @@ fn multibyte_atx_heading_escape() {
 fn multibyte_atx_heading_escape_umlaut() {
     let md = convert_faithful("<p>## über</p>").unwrap();
     assert_eq!(r"\## über", md);
+}
+
+/// Takes `html` back to HTML the long way round: `convert_faithful` writes the
+/// Markdown, and pulldown-cmark reads that Markdown back.
+///
+/// What comes back is HTML *source*, not a DOM, so a character reference in it
+/// is decoded only later, by whatever HTML parser reads the result. That is why
+/// several assertions below still hold a `&#10;`: it decodes to the line ending
+/// it replaced, so the trip is faithful even though the strings differ. Where a
+/// trip loses something instead, the assertion says what.
+fn round_trip(html: &str) -> String {
+    let markdown = convert_faithful(html).unwrap();
+    let parser = Parser::new_ext(&markdown, CommonMarkOptions::empty());
+    let mut html_output = String::new();
+    pulldown_cmark::html::push_html(&mut html_output, parser);
+    html_output
+}
+
+/// `script` and `style` open a
+/// [type 1 HTML block](https://spec.commonmark.org/0.31.2/#html-blocks), which
+/// runs to the line holding its closing tag: the element passes through whole,
+/// blank lines and Markdown specials alike. `div` is type 6, which ends at a
+/// blank line instead, so a blank line inside one has to be escaped. A tag
+/// outside both lists is type 7, which is written as a raw HTML inline whatever
+/// the context.
+///
+/// The tags the third "Special case" of `unsupported_html.md` sets aside —
+/// `iframe`, `xmp`, `noscript`, `noembed`, `noframes` and `plaintext` — are
+/// deliberately left uncovered here and in `round_trip_in_an_inline_context`.
+/// The tokenizer hands their content back as literal characters, so neither the
+/// escape below nor the walk an inline context uses can encode a line ending
+/// inside one; this implementation ignores those cases.
+#[test]
+fn round_trip_in_a_block_context() {
+    // Type 1: verbatim, both ways.
+    assert_eq!(
+        "<script>a*b\n\nc</script>",
+        round_trip("<script>a*b\n\nc</script>")
+    );
+    assert_eq!(
+        "<style>a*b\n\nc</style>",
+        round_trip("<style>a*b\n\nc</style>")
+    );
+
+    // Type 6: the escaped blank line decodes when an HTML parser reads this
+    // output, so the trip is faithful.
+    assert_eq!("<div>a*b\n&#10;c</div>", round_trip("<div>a*b\n\nc</div>"));
+
+    // Type 7 is a raw HTML inline, so CommonMark opens a paragraph around it —
+    // the tradeoff the "Translating HTML nodes" section of `unsupported_html.md`
+    // takes deliberately. The `*` survives, having been escaped as `a\*b`, but
+    // the blank line is compressed to a space on the way out.
+    assert_eq!(
+        "<p><del>a*b c</del></p>\n",
+        round_trip("<del>a*b\n\nc</del>")
+    );
+}
+
+/// A heading is a leaf block, so each element below is written as a raw HTML
+/// inline. Only its tags are HTML; what sits between them is CommonMark text,
+/// which is what makes the line-ending escape work here — the CommonMark parser
+/// decodes `&#10;` while producing that text, before any HTML parser sees a
+/// `<script>` element. The same fact cuts the other way for a raw text element:
+/// its content is passed through unescaped, so a Markdown special in it is read
+/// as Markdown.
+#[test]
+fn round_trip_in_an_inline_context() {
+    // The line ending survives, decoded by the CommonMark parser.
+    assert_eq!(
+        "<h1>x<script>a*b\nc</script>y</h1>\n",
+        round_trip("<h1>x<script>a*b\nc</script>y</h1>")
+    );
+    assert_eq!(
+        "<h1>x<style>a*b\nc</style>y</h1>\n",
+        round_trip("<h1>x<style>a*b\nc</style>y</h1>")
+    );
+
+    // A raw text element's content is serialized as it stands, so the Markdown
+    // it holds is read as Markdown rather than as the script or stylesheet it
+    // was. Escaping it would need the escape to survive an HTML parser which
+    // does not decode references inside these elements.
+    assert_eq!(
+        "<h1>x<script>a<em>b</em>c</script>y</h1>\n",
+        round_trip("<h1>x<script>a*b*c</script>y</h1>")
+    );
+    assert_eq!(
+        "<h1>x<style>a<em>b</em>c</style>y</h1>\n",
+        round_trip("<h1>x<style>a*b*c</style>y</h1>")
+    );
+    assert_eq!(
+        "<h1>x<script><a href=\"b\">a</a></script>y</h1>\n",
+        round_trip("<h1>x<script>[a](b)</script>y</h1>")
+    );
+    // A `<` in a script is left bare, and CommonMark escapes it on the way out.
+    assert_eq!(
+        "<h1>x<script>if(a&lt;b){}</script>y</h1>\n",
+        round_trip("<h1>x<script>if(a<b){}</script>y</h1>")
+    );
+    // An `&` does survive: the reference is written back as a reference.
+    assert_eq!(
+        "<h1>x<script>a&amp;b</script>y</h1>\n",
+        round_trip("<h1>x<script>a&amp;b</script>y</h1>")
+    );
+
+    // `textarea` and `title` are RCDATA rather than raw text: an HTML parser
+    // does decode a character reference inside one, so nothing forces them to
+    // be serialized verbatim and they take the ordinary raw HTML inline path.
+    // That path makes the opposite trade, the one the type 6 and type 7 cases
+    // below make: the Markdown special survives, and the line ending is the
+    // half that is lost.
+    assert_eq!(
+        "<h1>x<textarea>a*b c</textarea>y</h1>\n",
+        round_trip("<h1>x<textarea>a*b\nc</textarea>y</h1>")
+    );
+
+    // A type 6 or type 7 element takes the mirror-image trade: its content is
+    // walked as text, so a Markdown special in it is escaped and survives...
+    assert_eq!(
+        "<h1>x<div>a*b*c</div>y</h1>\n",
+        round_trip("<h1>x<div>a*b*c</div>y</h1>")
+    );
+    // ...but that walk compresses the line ending to a space instead of
+    // escaping it, so the line ending is the half that is lost.
+    assert_eq!(
+        "<h1>x<div>a*b c</div>y</h1>\n",
+        round_trip("<h1>x<div>a*b\nc</div>y</h1>")
+    );
+    assert_eq!(
+        "<h1>x<del>a*b c</del>y</h1>\n",
+        round_trip("<h1>x<del>a*b\nc</del>y</h1>")
+    );
 }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -230,7 +230,8 @@ fn a_raw_text_element_is_serialized_verbatim() {
         convert_faithful("<script>a*b\nc</script>").unwrap()
     );
     // The escaped line ending survives the trip back: a CommonMark parser
-    // decodes the reference while producing the raw HTML inline.
+    // decodes the reference while producing the raw HTML inline. See
+    // `round_trip_in_an_inline_context` in `basic_tests.rs`.
     assert_eq!(
         "# <script>a&#10;b</script>",
         convert_faithful("<h1><script>a\nb</script></h1>").unwrap()


### PR DESCRIPTION
The context tests assert what htmd writes; these assert what a CommonMark parser reads back from it, which is the property the design is actually after. pulldown-cmark joins as a dev-dependency to do the reading.

The two tests pin down where a trip is faithful and where it is not: a type 1 block passes through whole, a type 6 block's escaped blank line decodes on the way back, and in an inline context a raw text element keeps its line ending but loses its Markdown escaping while a type 6 or 7 element makes the opposite trade. Each assertion says which half of the trip survives.

Also refreshes Cargo.lock, which was missing the serde and serde_json dev-dependencies already declared in Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for converting HTML to Markdown and back, including block-level and inline content.
  - Added validation for escaped line endings and round-trip fidelity across various element types.

- **Documentation**
  - Clarified inline verbatim serialization behavior and linked it to the relevant round-trip coverage.
  - Expanded comments describing escaped line-ending handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->