### PR TITLE
Fix: encode the line endings of a link destination.

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -5,7 +5,7 @@ use crate::{
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
     options::{LinkReferenceStyle, LinkStyle},
-    text_util::{StripWhitespace, concat_strings, normalize_title},
+    text_util::{StripWhitespace, concat_strings, escape_link_destination, normalize_title},
 };
 
 /// Handler for HTML `<a>` (anchor) elements.
@@ -183,20 +183,4 @@ impl AnchorElementHandler {
             current
         })
     }
-}
-
-fn escape_link_destination(link: String) -> String {
-    if !link.contains(['(', ')']) {
-        return link;
-    }
-
-    let mut escaped = String::with_capacity(link.len());
-    for ch in link.chars() {
-        match ch {
-            '(' => escaped.push_str("\\("),
-            ')' => escaped.push_str("\\)"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -3,7 +3,7 @@ use crate::{
     dom_walker::{is_block_element, is_type_1_element},
     element_handler::{HandlerResult, Handlers},
     node_util::parent_tag_name_equals,
-    text_util::frame_as_block,
+    text_util::{frame_as_block, has_line_ending},
 };
 use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer, TraversalScope, serialize};
 use markup5ever_rcdom::{NodeData, SerializableHandle};
@@ -233,12 +233,6 @@ pub(crate) fn escape_inline_line_endings(html: String) -> String {
     result
 }
 
-/// Whether `html` holds anything for the escapes below to do: the fast path
-/// both of them share, and the one place the set of line endings they know
-/// about is written down.
-fn has_line_ending(html: &str) -> bool {
-    html.contains(['\r', '\n'])
-}
 
 // A blank line terminates a CommonMark HTML block. Encode every line ending
 // after the first so serialized block content remains in one HTML block.

--- a/src/element_handler/img.rs
+++ b/src/element_handler/img.rs
@@ -2,7 +2,7 @@ use crate::{
     Element,
     element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
-    text_util::{concat_strings, normalize_title},
+    text_util::{concat_strings, escape_link_destination, normalize_title},
 };
 
 pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
@@ -30,7 +30,7 @@ pub(super) fn img_handler(handlers: &dyn Handlers, element: Element) -> Option<H
     let alt = alt.as_deref().map(normalize_title);
     let title = title.as_deref().map(normalize_title);
 
-    let link = link.map(|text| text.replace('(', "\\(").replace(')', "\\)"));
+    let link = link.map(escape_link_destination);
 
     let has_spaces_in_link = link.as_ref().is_some_and(|link| link.contains(' '));
 

--- a/src/text_util.rs
+++ b/src/text_util.rs
@@ -142,6 +142,47 @@ pub(crate) fn frame_as_block(content: &str) -> String {
     concat_strings!("\n\n", content.trim_matches('\n'), "\n\n")
 }
 
+/// Whether `text` holds a line ending: the one place the set of line endings
+/// the escapes here and in `element_util` know about is written down.
+pub(crate) fn has_line_ending(text: &str) -> bool {
+    text.contains(['\r', '\n'])
+}
+
+/// Pushes `ch` onto `output`, writing a line ending as the character reference
+/// a CommonMark parser decodes back into it. Encoding this way lets a line
+/// ending sit inside a leaf block — a raw HTML inline, a link destination, a
+/// quoted title — which a bare one would end.
+///
+/// Being per-character, this is no use where a CRLF pair has to count as the
+/// one line ending it is; see `element_util::escape_html_block_blank_lines`.
+pub(crate) fn push_encoding_line_ending(output: &mut String, ch: char) {
+    match ch {
+        '\r' => output.push_str("&#13;"),
+        '\n' => output.push_str("&#10;"),
+        _ => output.push(ch),
+    }
+}
+
+/// Escapes a [link destination](https://spec.commonmark.org/0.31.2/#link-destination):
+/// the parentheses which would close it early, and the line endings it may not
+/// hold at all. A line ending becomes a character reference for the reason
+/// [`normalize_title`] gives.
+pub(crate) fn escape_link_destination(link: String) -> String {
+    if !link.contains(['(', ')']) && !has_line_ending(&link) {
+        return link;
+    }
+
+    let mut escaped = String::with_capacity(link.len());
+    for ch in link.chars() {
+        match ch {
+            '(' => escaped.push_str("\\("),
+            ')' => escaped.push_str("\\)"),
+            _ => push_encoding_line_ending(&mut escaped, ch),
+        }
+    }
+    escaped
+}
+
 /// Normalizes an `alt` or `title` attribute value for Markdown: each line is
 /// trimmed of document whitespace, blank lines are dropped, every `"` is
 /// escaped so the value can sit inside a quoted title, and what is left is
@@ -152,11 +193,7 @@ pub(crate) fn frame_as_block(content: &str) -> String {
 /// title, or the label an image takes its alt text from — and a line ending
 /// there ends the leaf block holding it, truncating an ATX heading or a table
 /// row. CommonMark recognizes character references in both places, so `&#10;`
-/// decodes back to the line ending it replaced; this is the same encoding
-/// [`escape_inline_line_endings`] applies to a raw HTML inline.
-///
-/// [`escape_inline_line_endings`]:
-///     crate::element_handler::element_util::escape_inline_line_endings
+/// decodes back to the line ending it replaced.
 pub(crate) fn normalize_title(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     for line in text.lines() {
@@ -173,8 +210,7 @@ pub(crate) fn normalize_title(text: &str) -> String {
                 // `lines()` splits on a line feed, so a lone carriage return —
                 // which an attribute value can still hold, written as `&#13;` —
                 // reaches here intact and needs the same encoding.
-                '\r' => result.push_str("&#13;"),
-                _ => result.push(ch),
+                _ => push_encoding_line_ending(&mut result, ch),
             }
         }
     }

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -63,3 +63,42 @@ fn links_inlined_prefer_autolinks() {
         converter.convert(html).unwrap()
     );
 }
+
+
+/// A line ending in a link destination ends the leaf block holding it: written
+/// literally, `a[t](u⏎⏎v)b` is two paragraphs and no link at all. CommonMark
+/// decodes a character reference in a destination, so it is encoded instead.
+#[test]
+fn a_link_destination_escapes_its_line_endings() {
+    assert_eq!(
+        "a[t](u&#10;v)b",
+        convert_faithful("<p>a<a href=\"u\nv\">t</a>b</p>").unwrap()
+    );
+    assert_eq!(
+        "a[t](u&#10;&#10;v)b",
+        convert_faithful("<p>a<a href=\"u\n\nv\">t</a>b</p>").unwrap()
+    );
+    assert_eq!(
+        "# a[t](u&#10;v)b",
+        convert_faithful("<h1>a<a href=\"u\nv\">t</a>b</h1>").unwrap()
+    );
+    // A carriage return reaches the destination only as a character reference,
+    // the parser having folded any literal CRLF into a line feed.
+    assert_eq!(
+        "a[t](u&#13;v)b",
+        convert_faithful("<p>a<a href=\"u&#13;v\">t</a>b</p>").unwrap()
+    );
+    // An image's destination takes the same encoding.
+    assert_eq!(
+        "a![](i&#10;j)b",
+        convert_faithful("<p>a<img src=\"i\nj\">b</p>").unwrap()
+    );
+    assert_eq!(
+        "[t](u)",
+        convert_faithful(r#"<p><a href="u">t</a></p>"#).unwrap()
+    );
+    assert_eq!(
+        r"[t](u\(v\))",
+        convert_faithful(r#"<p><a href="u(v)">t</a></p>"#).unwrap()
+    );
+}


### PR DESCRIPTION
This is the first in another series of PRs which implement more of the spec.

A CommonMark link destination may not hold a line ending at all: written literally, `a[t](u<LF><LF>v)b` is two paragraphs and no link. CommonMark does decode a character reference there, so `<CR>` and `<LF>` are written as `&#13;` and `&#10;`, the same encoding `normalize_title` already applies to a title.

`escape_link_destination` moves from `anchor` to `text_util` so `img` can use it too, replacing the `replace('(', ...)` pair which escaped the parentheses but left the line endings. The line ending encoding itself becomes `push_encoding_line_ending`, shared with `normalize_title`, and `has_line_ending` moves alongside it from `element_util`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of links and images containing parentheses in their destinations.
  - Line breaks in link and image destinations are now encoded consistently, preventing malformed generated Markdown.
  - Updated behavior applies across paragraphs and headings while leaving ordinary destinations unchanged.

- **Consistency**
  - Shared destination and line-ending handling now provides uniform output across supported elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->