### PR TITLE
Fix: replace the line endings of a math span with spaces.

### DIFF
--- a/src/element_handler/span.rs
+++ b/src/element_handler/span.rs
@@ -16,12 +16,30 @@ pub(super) fn span_handler(handlers: &dyn Handlers, element: Element) -> Option<
         && children.len() == 1
         && let NodeData::Text { contents } = &children[0].data
     {
-        if *attr.value == *"math math-inline" {
-            return Some(concat_strings!("$", contents.borrow().to_string(), "$").into());
-        }
-
-        if *attr.value == *"math math-display" {
-            return Some(concat_strings!("$$", contents.borrow().to_string(), "$$").into());
+        let delimiter = match &*attr.value {
+            "math math-inline" => Some("$"),
+            "math math-display" => Some("$$"),
+            _ => None,
+        };
+        if let Some(delimiter) = delimiter {
+            // Per the [spec](../unsupported_html.md), replace newlines with
+            // spaces: LaTeX ignores whitespace, while a line ending here would
+            // end the math span and begin another block. A CRLF pair is a
+            // single line ending, so it becomes a single space.
+            let contents = contents.borrow();
+            let mut math = String::with_capacity(contents.len());
+            let mut chars = contents.chars().peekable();
+            while let Some(c) = chars.next() {
+                match c {
+                    '\r' => {
+                        chars.next_if_eq(&'\n');
+                        math.push(' ');
+                    }
+                    '\n' => math.push(' '),
+                    _ => math.push(c),
+                }
+            }
+            return Some(concat_strings!(delimiter, math, delimiter).into());
         }
     }
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -415,3 +415,31 @@ fn a_serialized_element_follows_its_context() {
         convert_faithful("<ul><li><em foo>y</em></li></ul>").unwrap()
     );
 }
+
+
+/// The contents of a math span are literal text, but a line ending there would
+/// end the span and begin another block. LaTeX ignores whitespace, so each line
+/// ending becomes a space.
+#[test]
+fn a_math_span_replaces_its_line_endings_with_spaces() {
+    assert_eq!(
+        "x$a b$y",
+        convert_faithful("<p>x<span class=\"math math-inline\">a\nb</span>y</p>").unwrap()
+    );
+    assert_eq!(
+        "$$a b$$",
+        convert_faithful("<p><span class=\"math math-display\">a\nb</span></p>").unwrap()
+    );
+    // A carriage return reaches the span only as a character reference, the
+    // parser having folded any literal CRLF into a line feed. A CRLF pair is
+    // one line ending, so it becomes one space...
+    assert_eq!(
+        "$a b$",
+        convert_faithful("<p><span class=\"math math-inline\">a&#13;&#10;b</span></p>").unwrap()
+    );
+    // ...while a lone carriage return is a line ending of its own.
+    assert_eq!(
+        "$a b$",
+        convert_faithful("<p><span class=\"math math-inline\">a&#13;b</span></p>").unwrap()
+    );
+}


### PR DESCRIPTION
The Math section of `unsupported_html.md` asks for all newlines in math expressions to become spaces: a `$...$` span sits inside a leaf block, which a bare line ending would end, and no escape or encoding is decoded between the delimiters. LaTeX ignores whitespace, so a space stands in for the line ending rather than dropping it and joining the two lines. A CRLF pair is a single line ending and so becomes a single space.

The two `class` arms are folded into a single match on the delimiter so the replacement is written once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Math content now normalizes line endings to spaces before rendering.
  * Handles line feeds, carriage returns, and CRLF sequences consistently in inline and display math.

* **Tests**
  * Added coverage for line-ending normalization across supported math span formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->