### PR TITLE
Fix: additional math failing cases.

### DIFF
--- a/src/element_handler/span.rs
+++ b/src/element_handler/span.rs
@@ -28,8 +28,8 @@ pub(super) fn span_handler(handlers: &dyn Handlers, element: Element) -> Option<
             let contents = contents.replace("\n", " ");
             let contents = contents.replace("\r", " ");
             let contents = contents.trim();
-            // Math cannot be empty.
-            if !contents.is_empty() {
+            // Inline math cannot be empty.
+            if !contents.is_empty() || delimiter == "$$" {
                 return Some(concat_strings!(delimiter, contents, delimiter).into());
             }
         }

--- a/src/element_handler/span.rs
+++ b/src/element_handler/span.rs
@@ -22,24 +22,16 @@ pub(super) fn span_handler(handlers: &dyn Handlers, element: Element) -> Option<
             _ => None,
         };
         if let Some(delimiter) = delimiter {
-            // Per the [spec](../unsupported_html.md), replace newlines with
-            // spaces: LaTeX ignores whitespace, while a line ending here would
-            // end the math span and begin another block. A CRLF pair is a
-            // single line ending, so it becomes a single space.
+            // Per the [spec](unsupported_html.md), process math.
             let contents = contents.borrow();
-            let mut math = String::with_capacity(contents.len());
-            let mut chars = contents.chars().peekable();
-            while let Some(c) = chars.next() {
-                match c {
-                    '\r' => {
-                        chars.next_if_eq(&'\n');
-                        math.push(' ');
-                    }
-                    '\n' => math.push(' '),
-                    _ => math.push(c),
-                }
+            let contents = contents.replace("\r\n", " ");
+            let contents = contents.replace("\n", " ");
+            let contents = contents.replace("\r", " ");
+            let contents = contents.trim();
+            // Math cannot be empty.
+            if !contents.is_empty() {
+                return Some(concat_strings!(delimiter, contents, delimiter).into());
             }
-            return Some(concat_strings!(delimiter, math, delimiter).into());
         }
     }
 

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -416,7 +416,6 @@ fn a_serialized_element_follows_its_context() {
     );
 }
 
-
 /// The contents of a math span are literal text, but a line ending there would
 /// end the span and begin another block. LaTeX ignores whitespace, so each line
 /// ending becomes a space.

--- a/unsupported_html.md
+++ b/unsupported_html.md
@@ -351,9 +351,12 @@ Like an inline code span, the contents of
 [math expressions](https://pulldown-cmark.github.io/pulldown-cmark/specs/math.html)
 are literal text and are not parsed by CommonMark. However, newlines in
 single-line CommonMark blocks (such as a heading or a table cell) or blank lines
-in other blocks end the math span and begin another block. Since LaTex
+in other blocks end the math span and begin another block. Since LaTeX
 mathematics ignores newlines and other forms of whitespace, all newlines are
-replaced with spaces in math expressions to prevent these mis-translations.
+replaced with spaces in math expressions to prevent these mis-translations. In
+addition, leading and trailing whitespace is trimmed, since inline math may not
+begin or end with whitespace per the
+[pulldown-cmark spec](https://pulldown-cmark.github.io/pulldown-cmark/specs/math.html).
 
 Table cells
 -----------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Math expressions now handle CRLF, LF, and CR line endings consistently by converting them to spaces.
  - Surrounding whitespace is trimmed from math content.
  - Empty inline math is skipped, while empty display math remains serializable.

- **Documentation**
  - Updated math handling documentation to clarify newline and whitespace behavior and align terminology with the LaTeX specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->