### PR TITLE
Fix line encoding, tables with block elements

### DIFF
--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -255,7 +255,7 @@ fn escape_html_block_blank_lines(html: String) -> String {
             result.push(chars.next().unwrap());
         }
 
-        copy_horizontal_whitespace(&mut chars, &mut result);
+        copy_blank_line_whitespace(&mut chars, &mut result);
         let Some(next) = chars.next() else {
             break;
         };
@@ -271,18 +271,21 @@ fn escape_html_block_blank_lines(html: String) -> String {
                 continue;
             }
         }
-        copy_horizontal_whitespace(&mut chars, &mut result);
+        copy_blank_line_whitespace(&mut chars, &mut result);
     }
 
     result
 }
 
-fn copy_horizontal_whitespace<I>(chars: &mut std::iter::Peekable<I>, output: &mut String)
+/// Copies the run of spaces and tabs at `chars` — the only characters a
+/// [blank line](https://spec.commonmark.org/0.31.2/#characters-and-lines) may
+/// hold, so a line carrying any other whitespace ends no HTML block.
+fn copy_blank_line_whitespace<I>(chars: &mut std::iter::Peekable<I>, output: &mut String)
 where
     I: Iterator<Item = char>,
 {
     while let Some(&next) = chars.peek() {
-        if !next.is_whitespace() || next == '\r' || next == '\n' {
+        if next != ' ' && next != '\t' {
             break;
         }
         output.push(next);
@@ -345,5 +348,21 @@ mod tests {
             escape_html_block_blank_lines("a\r\n\r\nb".into())
         );
         assert_eq!("a\r&#13;b", escape_html_block_blank_lines("a\r\rb".into()));
+    }
+
+    #[test]
+    fn escapes_only_the_lines_which_are_blank() {
+        assert_eq!(
+            "a\n  &#10;b",
+            escape_html_block_blank_lines("a\n  \nb".into())
+        );
+        assert_eq!(
+            "a\n\t&#10;b",
+            escape_html_block_blank_lines("a\n\t\nb".into())
+        );
+        assert_eq!(
+            "a\n\u{0C}\nb",
+            escape_html_block_blank_lines("a\n\u{0C}\nb".into())
+        );
     }
 }

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -268,7 +268,7 @@ fn normalize_cell_content(content: &str) -> String {
     let content = content
         .replace('\n', " ")
         .replace('\r', "")
-        .replace('|', "&#124;");
+        .replace('|', "\\|");
     content.trim_document_whitespace().to_string()
 }
 

--- a/src/element_handler/td_th.rs
+++ b/src/element_handler/td_th.rs
@@ -1,31 +1,20 @@
 use crate::{
     Context, Element,
-    dom_walker::is_block_element,
     element_handler::element_util::handle_or_serialize_by_parent,
     element_handler::{HandlerResult, Handlers},
-    node_util::get_node_tag_name,
-    options::TranslationMode,
 };
 
 pub(super) fn td_th_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    // Are any of this node's children block elements?
-    let has_block_elements = handlers.options().translation_mode == TranslationMode::Faithful
-        && element
-            .node
-            .children
-            .borrow()
-            .iter()
-            .any(|child| get_node_tag_name(child).is_some_and(is_block_element));
     handle_or_serialize_by_parent(
         handlers,
         &element,
         &["tr"],
-        // Force HTML serialization in faithful mode if the table cell contains
-        // block elements.
-        if has_block_elements { -1 } else { 0 },
+        0,
         false,
         // A cell's contents are parsed as inline content, so no HTML block can
-        // open inside one.
+        // open inside one: an element which only HTML can express becomes a raw
+        // HTML inline here, whatever its tag. See the "Translating HTML nodes"
+        // section of `unsupported_html.md`.
         Context::Inline,
     )
 }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -166,6 +166,38 @@ fn html_in_a_table_cell_is_a_raw_inline() {
         )
         .unwrap()
     );
+    // A block element in a cell is a raw HTML inline like any other.
+    assert_eq!(
+        "| h        |\n| -------- |\n| <p>a</p> |",
+        convert_faithful(
+            "<table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td><p>a</p></td></tr></tbody></table>"
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        "| h                   |\n| ------------------- |\n| <ul><li>a</li></ul> |",
+        convert_faithful(
+            "<table><thead><tr><th>h</th></tr></thead>\
+             <tbody><tr><td><ul><li>a</li></ul></td></tr></tbody></table>"
+        )
+        .unwrap()
+    );
+}
+
+/// What a cell cannot absorb as a raw HTML inline is an attribute on the cell
+/// itself: a GFM row has nowhere to write one. The `<caption>` half of the same
+/// rule is covered by
+/// `basic_tests::faithful_mode_serializes_a_table_with_a_caption`. See the
+/// table cells section of `unsupported_html.md`.
+#[test]
+fn a_cell_attribute_writes_the_whole_table_as_html() {
+    let with_colspan = "<table><thead><tr><th>h</th></tr></thead>\
+                        <tbody><tr><td colspan=\"2\">a</td></tr></tbody></table>";
+    assert_eq!(with_colspan, convert_faithful(with_colspan).unwrap());
+    let heading_colspan = "<table><thead><tr><th colspan=\"2\">h</th></tr></thead>\
+                           <tbody><tr><td>a</td></tr></tbody></table>";
+    assert_eq!(heading_colspan, convert_faithful(heading_colspan).unwrap());
 }
 
 #[test]

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -280,25 +280,17 @@ Sample Table
         assert_eq!(expected, result);
     }
 
+    /// A cell's contents are parsed as inline content, so a block element in a
+    /// cell is written as a raw HTML inline and the table stays a table. See
+    /// the "Translating HTML nodes" section of `unsupported_html.md`.
     #[test]
     fn test_table_block_cells() {
         assert_eq!(
             indoc!(
                 r#"
-                <table>
-                    <thead>
-                        <tr>
-                            <th>a</th>
-                            <th><p>b</p></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>c</td>
-                            <td>d</td>
-                        </tr>
-                    </tbody>
-                </table>"#
+                | a | <p>b</p> |
+                | - | -------- |
+                | c | d        |"#
             ),
             // This has a block (a paragraph) in the table headings.
             convert_faithful(indoc!(


### PR DESCRIPTION
# Line encoding

`escape_html_block_blank_lines` encodes the line ending of a blank line
so serialized block content stays in one HTML block. It skipped every
horizontal whitespace character while looking for one, so a line holding
a form feed or a non-breaking space was treated as blank and its line
ending needlessly encoded.

A CommonMark blank line holds spaces and tabs alone, so the scan is
narrowed to those two and the helper renamed for what it now copies.

# Tables with block elements

Fix: keep a table whose cell holds a block element.

A GFM cell's contents are parsed as inline content, so an element only
HTML can express becomes a raw HTML inline there whatever its tag — the
"Translating HTML nodes" section of `unsupported_html.md`. `td_th_handler`
instead forced the cell itself out as HTML whenever a child was a block
element, which cascaded to the whole table: a `<p>` in one cell turned an
otherwise translatable table into a wall of serialized markup.

Dropping that check lets the cell keep its Markdown and write the block
element inline, so only what a GFM row genuinely cannot spell — an
attribute on the cell — still serializes the table.

A `|` in cell content is now escaped as `\|`, GFM's own escape, rather
than as the `&#124;` character reference, which reads back correctly but
leaves the reference visible to anything else consuming the Markdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown table conversion so literal pipe characters in cells are escaped correctly.
  - Preserved block elements inside table cells as raw HTML when generating Markdown tables.
  - Tables with cell attributes such as `colspan` are now serialized as HTML to preserve their structure.
  - Corrected blank-line handling so only spaces and tabs are treated as blank-line whitespace.
- **Tests**
  - Added coverage for HTML content, cell attributes, table formatting, and whitespace edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->