### PR TITLE
Table improvements

### DIFF
--- a/src/element_handler/caption.rs
+++ b/src/element_handler/caption.rs
@@ -1,11 +1,18 @@
 use crate::{
     Context, Element,
-    element_handler::element_util::handle_or_serialize_by_parent,
+    element_handler::element_util::serialize_if_extra_attrs,
     element_handler::{HandlerResult, Handlers},
+    text_util::frame_as_block,
 };
 
 pub(super) fn caption_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
-    // A caption is written as a paragraph above the table, and a paragraph is a
-    // leaf block: its children begin an inline context.
-    handle_or_serialize_by_parent(handlers, &element, &["table"], 0, true, Context::Inline)
+    // CommonMark has no caption, so faithful mode always writes the element as
+    // HTML. A `<caption>` is only valid inside a `<table>`, so `table_handler`
+    // serializes the whole table around it.
+    serialize_if_extra_attrs!(handlers, element, -1);
+    // Only pure mode reaches here. A caption is written as a paragraph above
+    // the table, and a paragraph is a leaf block: its children begin an inline
+    // context.
+    let content = handlers.walk_children_content(element.node, Context::Inline);
+    Some(frame_as_block(&content).into())
 }

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -53,9 +53,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
 
     let mut table_md = String::from("\n\n");
 
-    for caption in captions {
-        table_md.push_str(&format!("{caption}\n"));
-    }
+    table_md.push_str(&captions);
 
     let col_widths = compute_column_widths(&headers, &rows, num_columns);
 
@@ -72,7 +70,8 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
 }
 
 struct ExtractedTable {
-    captions: Vec<String>,
+    /// The caption blocks, each already terminated by its line ending.
+    captions: String,
     headers: Vec<String>,
     rows: Vec<Vec<String>>,
     all_children_translated: bool,
@@ -83,7 +82,7 @@ fn extract_table_content(
     table_node: &Rc<markup5ever_rcdom::Node>,
 ) -> ExtractedTable {
     let mut table = ExtractedTable {
-        captions: Vec::new(),
+        captions: String::new(),
         headers: Vec::new(),
         rows: Vec::new(),
         all_children_translated: true,
@@ -100,10 +99,15 @@ fn extract_table_content(
         match name.local.as_ref() {
             "caption" => {
                 if let Some(result) = handlers.handle(child, Context::Block) {
+                    // A caption which only HTML can express takes the whole
+                    // table with it: written as an HTML block of its own it
+                    // would land outside any table, where the "in body"
+                    // insertion mode drops the start tag as a parse error.
                     table.all_children_translated &= result.markdown_translated;
                     table
                         .captions
-                        .push(result.content.trim_document_whitespace().to_string());
+                        .push_str(result.content.trim_document_whitespace());
+                    table.captions.push('\n');
                 }
             }
             "thead" => {

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -28,7 +28,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
 
     let ExtractedTable {
         captions,
-        headers,
+        mut headers,
         rows,
         all_children_translated,
     } = extract_table_content(handlers, element.node);
@@ -51,16 +51,25 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         .len()
         .max(rows.iter().map(|row| row.len()).max().unwrap_or(0));
 
+    // A [GFM table](https://github.github.com/gfm/#tables-extension-) has no
+    // headerless form: the delimiter row which makes the block a table has to
+    // follow a header row. Faithful mode writes HTML rather than invent one;
+    // pure mode has no such fallback and writes an empty header row.
+    if handlers.options().translation_mode == TranslationMode::Faithful && headers.is_empty() {
+        return Some(serialize_element_result(handlers, &element));
+    }
+    if headers.is_empty() {
+        headers = vec![String::new(); num_columns];
+    }
+
     let mut table_md = String::from("\n\n");
 
     table_md.push_str(&captions);
 
     let col_widths = compute_column_widths(&headers, &rows, num_columns);
 
-    if !headers.is_empty() {
-        table_md.push_str(&format_row_padded(&headers, num_columns, &col_widths));
-        table_md.push_str(&format_separator_padded(num_columns, &col_widths));
-    }
+    table_md.push_str(&format_row_padded(&headers, num_columns, &col_widths));
+    table_md.push_str(&format_separator_padded(num_columns, &col_widths));
     for row in rows {
         table_md.push_str(&format_row_padded(&row, num_columns, &col_widths));
     }
@@ -290,7 +299,9 @@ fn format_row_padded(row: &[String], num_columns: usize, col_widths: &[usize]) -
 fn format_separator_padded(num_columns: usize, col_widths: &[usize]) -> String {
     let mut line = String::from("|");
     for (_, col_width) in col_widths.iter().enumerate().take(num_columns) {
-        line.push_str(&concat_strings!(" ", "-".repeat(*col_width), " |"));
+        // A column whose every cell is empty has a width of zero, and a
+        // delimiter cell holding no `-` stops the row being a delimiter row.
+        line.push_str(&concat_strings!(" ", "-".repeat((*col_width).max(1)), " |"));
     }
     line.push('\n');
     line

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -404,18 +404,42 @@ fn faithful_mode_table() {
     );
 }
 
+/// CommonMark has no caption, so faithful mode always writes the element as
+/// HTML — and a `<caption>` is only valid inside a `<table>`, so the whole table
+/// is serialized around it.
 #[test]
-fn faithful_mode_serializes_a_table_when_its_caption_requires_html() {
+fn faithful_mode_serializes_a_table_with_a_caption() {
     let html = concat!(
         r#"<table><caption><span class="label">Caption</span></caption>"#,
         "<tr><th>Header</th></tr><tr><td>Cell</td></tr></table>"
     );
+    // html5ever inserts the `<tbody>` around the rows.
     let expected = concat!(
         r#"<table><caption><span class="label">Caption</span></caption>"#,
         "<tbody><tr><th>Header</th></tr><tr><td>Cell</td></tr></tbody></table>"
     );
 
     assert_eq!(expected, convert_faithful(html).unwrap());
+    // The point of serializing the whole table: the `<caption>` comes back as
+    // an element rather than as the bare text an HTML block outside the table
+    // would give. The block is the whole document here, so pulldown-cmark
+    // writes it without the trailing line ending `assert_round_trips` expects.
+    assert_eq!(expected, round_trip(expected));
+}
+
+/// Pure mode has no HTML to fall back on, so it keeps writing the caption as a
+/// paragraph above the table.
+#[test]
+fn pure_mode_writes_a_caption_as_a_paragraph() {
+    let html = concat!(
+        "<table><caption>Caption</caption>",
+        "<tr><th>Header</th></tr><tr><td>Cell</td></tr></table>"
+    );
+
+    assert_eq!(
+        "Caption\n| Header |\n| ------ |\n| Cell   |",
+        htmd::convert(html).unwrap()
+    );
 }
 
 #[test]

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -198,16 +198,32 @@ mod table_tests_1 {
         </table>
         "#;
 
-        let expected = r#"
-Sample Table
-| John | 35 | New York      |
-| Jane | 28 | San Francisco |
-"#
-        .trim();
+        // A `<caption>` has no CommonMark spelling and is invalid outside a
+        // `<table>`, so faithful mode serializes the whole table.
+        let expected = html.trim();
 
         let markdown = convert_faithful(html).unwrap();
         let result = markdown.trim();
         assert_eq!(expected, result);
+    }
+
+    /// CommonMark has no caption: writing the content as a paragraph above the
+    /// table reads as one but is not one, so only pure mode does it.
+    #[test]
+    fn test_table_caption_is_commonmark_only_in_pure_mode() {
+        let html = concat!(
+            "<table><caption>Sample Table</caption>",
+            "<thead><tr><th>h</th></tr></thead>",
+            "<tbody><tr><td>John</td></tr></tbody></table>"
+        );
+
+        assert_eq!(
+            "Sample Table\n| h    |\n| ---- |\n| John |",
+            htmd::HtmlToMarkdown::new().convert(html).unwrap()
+        );
+        // A `<caption>` is only valid inside a `<table>`, so the whole table is
+        // serialized around it rather than the caption written on its own.
+        assert_eq!(html, convert_faithful(html).unwrap());
     }
 
     #[test]

--- a/tests/table_tests.rs
+++ b/tests/table_tests.rs
@@ -226,6 +226,36 @@ mod table_tests_1 {
         assert_eq!(html, convert_faithful(html).unwrap());
     }
 
+    /// A GFM table has no headerless form: the delimiter row which makes the
+    /// block a table has to follow a header row.
+    #[test]
+    fn a_table_with_no_header_row_is_written_as_html() {
+        let html = concat!(
+            "<table><tbody><tr><td>a</td><td>b</td></tr>",
+            "<tr><td>c</td><td>d</td></tr></tbody></table>"
+        );
+        assert_eq!(html, convert_faithful(html).unwrap());
+
+        // A block element in a cell is a raw HTML inline and no reason to
+        // serialize; the missing header row is the reason here.
+        let block_cell = "<table><tbody><tr><td><p>a</p></td></tr></tbody></table>";
+        assert_eq!(block_cell, convert_faithful(block_cell).unwrap());
+    }
+
+    /// Pure mode has no HTML to fall back on, so it writes an empty header row.
+    /// A table is only built where the markup holds a `th` or a `thead`, hence
+    /// the empty `<thead>` needed to reach this.
+    #[test]
+    fn pure_mode_writes_an_empty_header_row_for_a_headerless_table() {
+        let html = "<table><thead></thead><tbody><tr><td>a</td></tr></tbody></table>";
+
+        assert_eq!(
+            "|   |\n| - |\n| a |",
+            htmd::HtmlToMarkdown::new().convert(html).unwrap()
+        );
+        assert_eq!(html, convert_faithful(html).unwrap());
+    }
+
     #[test]
     fn test_empty_table() {
         let html = "<table></table>";


### PR DESCRIPTION
# Fix 1

CommonMark has no caption. Writing the content as a paragraph above the
table reads as one but is not one, so faithful mode must write the
element itself — and since a `<caption>` is only valid inside a
`<table>`, an HTML block of its own would land outside any table, where
the "in body" insertion mode drops the start tag as a parse error.

`caption_handler` therefore always serializes in faithful mode, which
`table_handler` already turns into a serialization of the whole table
through `all_children_translated`. Pure mode keeps the paragraph.

`ExtractedTable::captions` becomes the `String` it was always joined
into.

# Fix 2

A GFM table has no headerless form: the delimiter row which makes the
block a table has to follow a header row. `table_handler` simply omitted
both rows when it had no headers, so the body rows came back as a
paragraph of pipes rather than as a table.

Faithful mode now writes the table as HTML instead of inventing a header
it never had. Pure mode has no such fallback, so it writes an empty
header row.

A delimiter cell also needs at least one `-`, which a column whose every
cell is empty would otherwise not get.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pure mode now renders table captions as paragraphs above the table.
  * Pure mode supports headerless tables by emitting an empty header row.
  * Table delimiter rows remain valid even when cells are empty.

* **Bug Fixes**
  * Faithful mode preserves tables with captions or without headers as HTML instead of altering their structure.
  * Improved caption handling maintains round-trip fidelity for supported table content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->