### PR TITLE
Fix: walk the content of every raw HTML inline.

### DIFF
--- a/src/dom_walker.rs
+++ b/src/dom_walker.rs
@@ -3,10 +3,7 @@ use markup5ever_rcdom::{Node, NodeData};
 use phf::phf_set;
 use std::{borrow::Cow, cell::RefCell, rc::Rc};
 
-use crate::{
-    Context,
-    element_handler::{ElementHandlers, element_util::escape_inline_line_endings},
-};
+use crate::{Context, element_handler::ElementHandlers};
 
 use super::{
     options::TranslationMode,
@@ -52,7 +49,7 @@ pub(crate) fn walk_node(
             output,
             parent_tag,
             trim_leading_spaces,
-            state.is_pre,
+            state,
         ),
         NodeData::Element { name, attrs, .. } => walk_element(
             node,
@@ -76,25 +73,18 @@ pub(crate) fn walk_node(
 /// A comment is an
 /// [HTML block](https://spec.commonmark.org/0.31.2/#html-blocks) of type 2,
 /// which ends at its own `-->` rather than at a blank line: in a block context
-/// it is framed as a block and its line endings are left as they are. In an
-/// inline context it is a raw HTML inline instead, and its line endings are
-/// escaped.
+/// it is framed as a block and its line endings are left as they are.
 ///
-/// **That escape is an incorrect workaround.** The "Translating HTML nodes"
-/// table of `unsupported_html.md` gives a type 2-5 node in an inline context a
-/// newline encoding of `None`, because encoding works only where the HTML
-/// parser decodes character references and it decodes none inside a comment:
-/// the `&#10;` written here comes back as those five characters rather than as
-/// the line ending it replaced. It is kept because the conforming alternative
-/// is worse — a bare line ending ends the leaf block holding the comment,
-/// splitting a paragraph in two or cutting an ATX heading or a table row short.
-/// Representing this faithfully needs the containing block serialized instead,
-/// which is the "Special case" that document sets aside.
+/// In an inline context it is a raw HTML inline, whose whitespace the
+/// "Translating HTML nodes" section of `unsupported_html.md` collapses.
+/// Encoding the line endings instead would be no use: no parser decodes a
+/// character reference inside a comment.
 fn walk_comment(contents: &str, output: &mut String, state: WalkState) {
     let html = concat_strings!("<!--", contents, "-->");
-    match state.context {
-        Context::Block => append_normalized_content(output, frame_as_block(&html), state.is_pre),
-        Context::Inline => output.push_str(&escape_inline_line_endings(html)),
+    if state.context == Context::Block {
+        append_normalized_content(output, frame_as_block(&html), state.is_pre);
+    } else {
+        output.push_str(&compress_whitespace(&html));
     }
 }
 
@@ -103,9 +93,9 @@ fn walk_text(
     output: &mut String,
     parent_tag: Option<&str>,
     trim_leading_spaces: bool,
-    is_pre: bool,
+    state: WalkState,
 ) -> bool {
-    if is_pre {
+    if state.is_pre {
         let text = if parent_tag == Some("pre") {
             escape_pre_text_if_needed(Cow::Borrowed(text))
         } else {
@@ -290,7 +280,11 @@ pub(crate) fn walk_children(
             _ => false,
         };
 
-        if is_block {
+        // Preformatted content keeps every space it holds, so a block inside
+        // one trims nothing.
+        let trims_spaces = is_block && !state.is_pre;
+
+        if trims_spaces {
             // Trim trailing spaces for the previous element
             trim_output_end_spaces(output);
         }
@@ -301,7 +295,7 @@ pub(crate) fn walk_children(
 
         if output.len() > output_len {
             // Something was appended, update the flag
-            trim_leading_spaces = is_block;
+            trim_leading_spaces = trims_spaces;
         }
 
         index = run_end;
@@ -403,8 +397,8 @@ fn combine_nodes(parent: &Rc<Node>, nodes: &[Rc<Node>]) -> Rc<Node> {
 
 /// Normalizes content before adding to output by:
 /// 1. Collapsing excessive newlines (max 2 consecutive newlines)
-/// 2. Collapsing adjacent spaces between inline elements (when not in pre context)
-fn append_normalized_content(output: &mut String, mut content: String, is_pre: bool) {
+/// 2. Collapsing adjacent spaces between inline elements
+fn append_normalized_content(output: &mut String, mut content: String, preserve_whitespace: bool) {
     if output.is_empty() {
         *output = content;
         return;
@@ -421,8 +415,8 @@ fn append_normalized_content(output: &mut String, mut content: String, is_pre: b
         content.drain(..to_remove);
     }
 
-    // Collapse adjacent spaces between inline elements (not in pre context)
-    let content = if !is_pre
+    // Collapse adjacent spaces between inline elements
+    let content = if !preserve_whitespace
         && last_newlines == 0
         && content_newlines == 0
         && output.ends_with(' ')

--- a/src/element_handler/code.rs
+++ b/src/element_handler/code.rs
@@ -6,7 +6,10 @@ use markup5ever_rcdom::{Node, NodeData};
 use crate::{
     Element,
     element_handler::element_util::serialize_if_extra_attrs,
-    element_handler::{HandlerResult, Handlers, element_util::serialize_element_result},
+    element_handler::{
+        HandlerResult, Handlers,
+        element_util::{serialize_element_result, serialize_element_when_faithful},
+    },
     node_util::{get_node_tag_name, get_parent_node},
     options::{CodeBlockFence, CodeBlockStyle, TranslationMode},
     text_util::{JoinOnStringIterator, TrimDocumentWhitespace, concat_strings},
@@ -44,6 +47,8 @@ fn handle_code_block(
     element: Element,
     parent: &Rc<Node>,
 ) -> Option<HandlerResult> {
+    // A code block is a CommonMark block, so it needs a block context.
+    serialize_element_when_faithful!(handlers, element, element.context.is_inline());
     // `<code>` begins no block of its own, so it passes on its context: the
     // inline context begun by the `<pre>` this is the code block of.
     let content = handlers.walk_children_content(element.node, element.context);

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -3,11 +3,10 @@ use crate::{
     dom_walker::{is_block_element, is_type_1_element},
     element_handler::{HandlerResult, Handlers},
     node_util::parent_tag_name_equals,
-    text_util::{frame_as_block, has_line_ending},
+    text_util::{frame_as_block, has_line_ending, push_encoding_line_ending},
 };
 use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer, TraversalScope, serialize};
 use markup5ever_rcdom::{NodeData, SerializableHandle};
-use phf::phf_set;
 use std::io::{self, Write};
 
 /// Returns from the enclosing handler with `content` as the element's HTML,
@@ -51,7 +50,7 @@ pub(super) fn handle_or_serialize_by_parent(
 ) -> Option<HandlerResult> {
     serialize_when_faithful!(
         handlers,
-        element.context == Context::Inline
+        element.context.is_inline()
             || element.attrs.len() as i64 > num_attrs_allowed
             || !parent_tag_name_equals(element.node, tag_names),
         serialize_element(handlers, element)
@@ -87,40 +86,9 @@ fn try_serialize_element(handlers: &dyn Handlers, element: &Element) -> io::Resu
     // `unsupported_html.md`.
     if element.context == Context::Block && is_block_element(element.tag) {
         serialize_block_element(element)
-    } else if is_raw_text_element(element.tag) {
-        // What a raw text element holds is literal characters, not markup, so
-        // translating it the way `serialize_inline_element` does would rewrite
-        // the text itself.
-        serialize_inline_verbatim(element)
     } else {
         serialize_inline_element(handlers, element)
     }
-}
-
-/// The tags whose content an HTML parser reads as raw text: no markup, and no
-/// character references either. That second half is what rules out translating
-/// them; see [`serialize_inline_verbatim`]. The RCDATA elements `textarea` and
-/// `title` are deliberately absent — an HTML parser does decode references
-/// inside those, so they take the ordinary raw HTML inline path, where the
-/// Markdown their content holds is escaped along with it.
-///
-/// **In an inline context that path does not meet the newline encoding the
-/// "Translating HTML nodes" table of `unsupported_html.md` asks of these two
-/// tags** — type 1 for `textarea`, type 6 for `title`. Walking the content as
-/// CommonMark is what escapes the Markdown in it, and that same walk compresses
-/// a line ending to a space before anything can encode it:
-/// `<h1><textarea>a⏎b</textarea></h1>` is written `# <textarea>a b</textarea>`,
-/// not `# <textarea>a&#10;b</textarea>`. Keeping both halves would need a walk
-/// which preserves whitespace *and* escapes Markdown specials, and neither mode
-/// the walker has does both — `is_pre_element` content preserves whitespace but
-/// goes out unescaped. The line ending is what is given up, because giving up
-/// the escaping instead would let `a*b*c` in a textarea come back as emphasis.
-static RAW_TEXT_ELEMENTS: phf::Set<&'static str> = phf_set! {
-    "script", "style",
-};
-
-fn is_raw_text_element(tag: &str) -> bool {
-    RAW_TEXT_ELEMENTS.contains(tag)
 }
 
 fn serialize_opts() -> SerializeOpts {
@@ -144,18 +112,21 @@ fn serialize_inline_element(handlers: &dyn Handlers, element: &Element) -> io::R
             .iter()
             .map(|attr| (&attr.name, &attr.value[..])),
     )?;
-    serializer
-        .writer
-        // What a raw HTML inline holds is inline content, whatever context the
-        // element itself appears in.
-        .write_all(
-            handlers
-                .walk_children_content(element.node, Context::Inline)
-                .as_bytes(),
-        )?;
+    // Everything written so far is the open tag, whose attribute values hold
+    // the only whitespace of this element the walk below does not reach.
+    let open_tag_len = serializer.writer.len();
+    serializer.writer.write_all(
+        handlers
+            .walk_raw_html_inline_children(element.node)
+            .as_bytes(),
+    )?;
     serializer.end_elem(name.clone())?;
-    let html = String::from_utf8(bytes).map_err(io::Error::other)?;
-    Ok(escape_inline_line_endings(html))
+    let mut html = String::from_utf8(bytes).map_err(io::Error::other)?;
+    if has_line_ending(&html[..open_tag_len]) {
+        let encoded = escape_attribute_line_endings(&html[..open_tag_len]);
+        html.replace_range(..open_tag_len, &encoded);
+    }
+    Ok(html)
 }
 
 fn serialize_block_element(element: &Element) -> io::Result<String> {
@@ -175,35 +146,6 @@ fn serialize_block_element(element: &Element) -> io::Result<String> {
     Ok(frame_as_block(&html))
 }
 
-/// [`serialize_inline_verbatim`] for callers outside this module.
-pub(crate) fn serialize_element_verbatim(element: &Element) -> String {
-    serialize_inline_verbatim(element).unwrap_or_else(|error| error.to_string())
-}
-
-/// Serializes `element` and everything it holds as HTML, translating none of
-/// it. Unlike a raw HTML inline, whose content is still translated, the content
-/// of a code block or a raw text element is literal text: no CommonMark
-/// encoding survives there. The result is a raw HTML inline, so its line
-/// endings are escaped as well.
-///
-/// A line ending does survive this: only the tags of a raw HTML inline are
-/// HTML, so a CommonMark parser reads what sits between them as text and
-/// decodes the `&#13;`/`&#10;` there before any HTML parser sees a `<script>`
-/// element. `round_trip_in_an_inline_context` in `tests/basic_tests.rs` shows
-/// the trip.
-///
-/// **Limitation:** that same fact costs the content its escaping. Serializing
-/// it leaves any Markdown special it holds bare, and the CommonMark parser
-/// reading it back takes that special as Markdown — `a*b*c` in a script comes
-/// back as `a<em>b</em>c`. Escaping the content instead would need an escape
-/// which survives an HTML parser, and a character reference is not one: inside
-/// a raw text element it stays those five or six characters. Representing this
-/// faithfully needs the containing block serialized instead, which is the
-/// "Special case" section of `unsupported_html.md`.
-fn serialize_inline_verbatim(element: &Element) -> io::Result<String> {
-    serialize_subtree(element).map(escape_inline_line_endings)
-}
-
 fn serialize_subtree(element: &Element) -> io::Result<String> {
     let mut bytes = Vec::new();
     let handle = SerializableHandle::from(element.node.clone());
@@ -211,28 +153,22 @@ fn serialize_subtree(element: &Element) -> io::Result<String> {
     String::from_utf8(bytes).map_err(io::Error::other)
 }
 
-// A raw HTML inline lives inside a leaf block, and every leaf block is ended by
-// a line ending it does not expect: a blank line ends the paragraph holding one,
-// a single line ending ends an ATX heading or a table row. Encode every line
-// ending, the safe over-generalization of the blank line rule described in
-// `unsupported_html.md`. A character reference in a raw HTML inline's tag or in
-// the CommonMark text it holds decodes back to the line ending it replaced.
-pub(crate) fn escape_inline_line_endings(html: String) -> String {
-    if !has_line_ending(&html) {
-        return html;
-    }
-
-    let mut result = String::with_capacity(html.len());
-    for ch in html.chars() {
-        match ch {
-            '\r' => result.push_str("&#13;"),
-            '\n' => result.push_str("&#10;"),
-            _ => result.push(ch),
-        }
+/// Writes every line ending in the open tag of a raw HTML inline as a
+/// character reference.
+///
+/// A raw HTML inline lives inside a leaf block, which a line ending ends: a
+/// blank one ends a paragraph, a single one an ATX heading or a table row. The
+/// contents are kept safe by the whitespace collapsing of the walk, but
+/// `unsupported_html.md` leaves an attribute value's whitespace alone, so a
+/// line ending there is encoded instead — the open tag passes through
+/// CommonMark verbatim, and the HTML parser reading the result decodes it back.
+fn escape_attribute_line_endings(open_tag: &str) -> String {
+    let mut result = String::with_capacity(open_tag.len());
+    for ch in open_tag.chars() {
+        push_encoding_line_ending(&mut result, ch);
     }
     result
 }
-
 
 // A blank line terminates a CommonMark HTML block. Encode every line ending
 // after the first so serialized block content remains in one HTML block.
@@ -293,16 +229,31 @@ where
     }
 }
 
+/// Returns from the enclosing handler with `element` written as HTML when
+/// `condition` holds and the mode is faithful. The macros below are spellings
+/// of this with the condition filled in.
+macro_rules! serialize_element_when_faithful {
+    ($handlers:expr, $element:expr, $condition:expr) => {
+        $crate::element_handler::element_util::serialize_when_faithful!(
+            $handlers,
+            $condition,
+            $crate::element_handler::element_util::serialize_element($handlers, &$element)
+        )
+    };
+}
+
+pub(crate) use serialize_element_when_faithful;
+
 /// Returns from the enclosing handler with `element` written as HTML when it
 /// carries more attributes than its Markdown translation can express.
 /// `num_attrs_allowed` of -1 rejects every attribute set, serializing the
 /// element whenever the mode is faithful; [`i64::MAX`] accepts any.
 macro_rules! serialize_if_extra_attrs {
     ($handlers:expr, $element:expr, $num_attrs_allowed:expr) => {
-        $crate::element_handler::element_util::serialize_when_faithful!(
+        $crate::element_handler::element_util::serialize_element_when_faithful!(
             $handlers,
-            $element.attrs.len() as i64 > $num_attrs_allowed,
-            $crate::element_handler::element_util::serialize_element($handlers, &$element)
+            $element,
+            $element.attrs.len() as i64 > $num_attrs_allowed
         )
     };
 }
@@ -317,11 +268,10 @@ pub(crate) use serialize_if_extra_attrs;
 /// they are tried in does not matter.
 macro_rules! serialize_if_extra_attrs_or_inline {
     ($handlers:expr, $element:expr, $num_attrs_allowed:expr) => {
-        $crate::element_handler::element_util::serialize_when_faithful!(
+        $crate::element_handler::element_util::serialize_element_when_faithful!(
             $handlers,
-            $element.context == $crate::Context::Inline
-                || $element.attrs.len() as i64 > $num_attrs_allowed,
-            $crate::element_handler::element_util::serialize_element($handlers, &$element)
+            $element,
+            $element.context.is_inline() || $element.attrs.len() as i64 > $num_attrs_allowed
         )
     };
 }
@@ -330,14 +280,16 @@ pub(crate) use serialize_if_extra_attrs_or_inline;
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_html_block_blank_lines, escape_inline_line_endings};
+    use super::{escape_attribute_line_endings, escape_html_block_blank_lines};
 
     #[test]
-    fn escapes_every_line_ending_of_a_raw_inline() {
-        assert_eq!("ab", escape_inline_line_endings("ab".into()));
-        assert_eq!("a&#10;b", escape_inline_line_endings("a\nb".into()));
-        assert_eq!("a&#13;&#10;b", escape_inline_line_endings("a\r\nb".into()));
-        assert_eq!("a&#13;b", escape_inline_line_endings("a\rb".into()));
+    fn escapes_the_line_endings_of_an_open_tag() {
+        assert_eq!("ab", escape_attribute_line_endings("ab"));
+        assert_eq!("a&#10;b", escape_attribute_line_endings("a\nb"));
+        assert_eq!("a&#13;&#10;b", escape_attribute_line_endings("a\r\nb"));
+        assert_eq!("a&#13;b", escape_attribute_line_endings("a\rb"));
+        assert_eq!("a&#10;&#10;b", escape_attribute_line_endings("a\n\nb"));
+        assert_eq!("a \t b", escape_attribute_line_endings("a \t b"));
     }
 
     #[test]

--- a/src/element_handler/mod.rs
+++ b/src/element_handler/mod.rs
@@ -118,6 +118,39 @@ pub(crate) struct ElementHandlers {
 }
 
 impl ElementHandlers {
+    /// The body [`Handlers::walk_children`] and
+    /// [`Handlers::walk_raw_html_inline_children`] share; they differ only in
+    /// the state they walk under.
+    fn walk_children_with(
+        &self,
+        node: &Rc<Node>,
+        is_block: bool,
+        state: WalkState,
+    ) -> HandlerResult {
+        let mut output = String::new();
+        let markdown_translated =
+            crate::dom_walker::walk_children(node, &mut output, self, is_block, state);
+        HandlerResult {
+            content: output,
+            markdown_translated,
+        }
+    }
+
+    /// Whether a walk of `node` writes literal text: the content of a
+    /// CommonMark code span or code block, which goes out with its whitespace
+    /// kept and no escape written. `tag` is the node's own tag name when the
+    /// walk goes inside it, and `None` when the walk starts at the node itself.
+    ///
+    /// The ancestor scan is a pure mode question only. Faithful mode translates
+    /// a `<code>` only when every child of it is a text node, and a `<pre>`
+    /// only when its one child is such a `<code>`, so an element inside either
+    /// means that ancestor is being written as HTML — and a raw HTML inline
+    /// holds CommonMark text rather than literal text.
+    fn is_pre_content(&self, node: &Rc<Node>, tag: Option<&str>) -> bool {
+        tag.is_some_and(is_pre_element)
+            || (self.options.translation_mode == TranslationMode::Pure && is_inside_pre(node))
+    }
+
     pub fn new(options: Options) -> Self {
         let mut handlers = Self {
             handlers: Vec::new(),
@@ -266,6 +299,15 @@ pub trait Handlers {
     /// status.
     fn walk_children(&self, node: &Rc<Node>, context: Context) -> HandlerResult;
 
+    /// Walks the children of `node` as the content of a raw HTML inline, whose
+    /// tags `element_util::serialize_inline_element` writes around the result.
+    ///
+    /// Unlike [`Handlers::walk_children`] with [`Context::Inline`], `node`
+    /// itself writes no literal text even when it is a `<pre>` or a `<code>`:
+    /// those tags are being written as HTML rather than translated to a code
+    /// block or span, so what sits between them is CommonMark text.
+    fn walk_raw_html_inline_children(&self, node: &Rc<Node>) -> String;
+
     /// The content of [`Handlers::walk_children`], for the many handlers whose
     /// own translation status does not depend on their children's.
     fn walk_children_content(&self, node: &Rc<Node>, context: Context) -> String {
@@ -291,7 +333,7 @@ impl Handlers for ElementHandlers {
     fn handle(&self, node: &Rc<Node>, context: Context) -> Option<HandlerResult> {
         let mut output = String::new();
         let state = WalkState {
-            is_pre: is_inside_pre(node),
+            is_pre: self.is_pre_content(node, None),
             context,
         };
         let markdown_translated = walk_node(node, &mut output, self, None, true, state);
@@ -302,21 +344,29 @@ impl Handlers for ElementHandlers {
     }
 
     fn walk_children(&self, node: &Rc<Node>, context: Context) -> HandlerResult {
-        let mut output = String::new();
         let tag = crate::node_util::get_node_tag_name(node);
-        let is_block = tag.is_some_and(crate::dom_walker::is_block_element);
-        let state = WalkState {
-            // Unlike `handle`, which walks the node itself, this walks inside
-            // it, so the node's own tag counts too.
-            is_pre: tag.is_some_and(is_pre_element) || is_inside_pre(node),
-            context,
-        };
-        let markdown_translated =
-            crate::dom_walker::walk_children(node, &mut output, self, is_block, state);
-        HandlerResult {
-            content: output,
-            markdown_translated,
-        }
+        self.walk_children_with(
+            node,
+            tag.is_some_and(crate::dom_walker::is_block_element),
+            WalkState {
+                is_pre: self.is_pre_content(node, tag),
+                context,
+            },
+        )
+    }
+
+    fn walk_raw_html_inline_children(&self, node: &Rc<Node>) -> String {
+        self.walk_children_with(
+            node,
+            false,
+            WalkState {
+                is_pre: false,
+                // What a raw HTML inline holds is inline content, whatever
+                // context the element itself appears in.
+                context: Context::Inline,
+            },
+        )
+        .content
     }
 
     fn options(&self) -> &Options {

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -1,10 +1,10 @@
 use crate::{
-    Context, Element,
+    Element,
     element_handler::{
         HandlerResult, Handlers,
         element_util::{
-            serialize_element, serialize_element_result, serialize_element_verbatim,
-            serialize_if_extra_attrs, serialize_when_faithful,
+            serialize_element, serialize_element_result, serialize_if_extra_attrs_or_inline,
+            serialize_when_faithful,
         },
     },
     node_util::get_node_tag_name,
@@ -14,17 +14,12 @@ use crate::{
 
 pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<HandlerResult> {
     // A code block is a CommonMark block, so it needs a block context. In an
-    // inline context it is written as a raw HTML inline instead — one holding
-    // no CommonMark, since a code block's content is literal text.
-    serialize_when_faithful!(
-        handlers,
-        element.context == Context::Inline,
-        serialize_element_verbatim(&element)
-    );
-    serialize_if_extra_attrs!(handlers, element, 0);
+    // inline context this `<pre>` is a raw HTML inline instead, its content
+    // walked like that of any other one.
+    serialize_if_extra_attrs_or_inline!(handlers, element, 0);
     // The only faithful translation for this is from
     // `<pre><code>blah</code></pre>` to a code block. So, check that this node
-    // has only one element, a pure `<code>` element. Cases:
+    // has only one element, a pure `<code>` element. Cases:
     //
     // 1.  We're in pure translation mode. No special treatment.
     // 2.  We're in faithful mode:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,26 @@ pub fn convert(html: &str) -> Result<String, std::io::Error> {
     HtmlToMarkdown::new().convert(html)
 }
 
-/// The CommonMark context an element is translated in. See the "Translating
-/// HTML nodes" section of `unsupported_html.md`.
+/// The CommonMark context an element is translated in: the root and a
+/// container block's contents are a block context, a leaf block's and a raw
+/// HTML inline's an inline one. See the "Translating HTML nodes" section of
+/// `unsupported_html.md`.
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Context {
     /// A block may begin here: the document root and the contents of a
     /// container block.
     Block,
-    /// Only inline content may appear here: the contents of a leaf block.
+    /// Only inline content may appear here: the contents of a leaf block, and
+    /// the contents of a raw HTML inline.
     Inline,
+}
+
+impl Context {
+    /// Whether only inline content may appear here, in which case an element
+    /// whose Markdown is a block is written as HTML instead.
+    pub fn is_inline(self) -> bool {
+        self == Context::Inline
+    }
 }
 
 /// The DOM element.

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -764,14 +764,16 @@ fn round_trip(html: &str) -> String {
 /// inside one; this implementation ignores those cases.
 #[test]
 fn round_trip_in_a_block_context() {
-    // Type 1: verbatim, both ways.
+    // Type 1: verbatim, both ways. Without the `<body>`, html5ever files a
+    // leading `<script>` or `<style>` under the `<head>`, whose content is
+    // dropped.
     assert_eq!(
         "<script>a*b\n\nc</script>",
-        round_trip("<script>a*b\n\nc</script>")
+        round_trip("<body><script>a*b\n\nc</script></body>")
     );
     assert_eq!(
         "<style>a*b\n\nc</style>",
-        round_trip("<style>a*b\n\nc</style>")
+        round_trip("<body><style>a*b\n\nc</style></body>")
     );
 
     // Type 6: the escaped blank line decodes when an HTML parser reads this
@@ -780,79 +782,54 @@ fn round_trip_in_a_block_context() {
 
     // Type 7 is a raw HTML inline, so CommonMark opens a paragraph around it —
     // the tradeoff the "Translating HTML nodes" section of `unsupported_html.md`
-    // takes deliberately. The `*` survives, having been escaped as `a\*b`, but
-    // the blank line is compressed to a space on the way out.
+    // takes deliberately. The `*` survives, escaped as `a\*b`; the blank line
+    // does not, a raw HTML inline having its whitespace collapsed.
     assert_eq!(
         "<p><del>a*b c</del></p>\n",
         round_trip("<del>a*b\n\nc</del>")
     );
+    // The loss the same section names: `<br><br>` at the root stays `<br><br>`,
+    // which reads back inside the paragraph CommonMark opens around it.
+    assert_eq!("<p><br><br></p>\n", round_trip("<br><br>"));
+    // A lone `<br>` meets the type 7 start condition, so it comes back as the
+    // HTML block it opened.
+    assert_eq!("<br>", round_trip("<br>"));
 }
 
 /// A heading is a leaf block, so each element below is written as a raw HTML
 /// inline. Only its tags are HTML; what sits between them is CommonMark text,
-/// which is what makes the line-ending escape work here — the CommonMark parser
-/// decodes `&#10;` while producing that text, before any HTML parser sees a
-/// `<script>` element. The same fact cuts the other way for a raw text element:
-/// its content is passed through unescaped, so a Markdown special in it is read
-/// as Markdown.
+/// which is what makes the escape of `a\*b` work here — the CommonMark parser
+/// consumes the backslash before any HTML parser sees a `<script>` element.
+/// `round_trip_losses_of_a_walked_raw_inline` holds the cases where reading
+/// that content as text costs something.
 #[test]
 fn round_trip_in_an_inline_context() {
-    // The line ending survives, decoded by the CommonMark parser.
+    // The Markdown special survives; the line ending is collapsed to a space.
     assert_eq!(
-        "<h1>x<script>a*b\nc</script>y</h1>\n",
+        "<h1>x<script>a*b c</script>y</h1>\n",
         round_trip("<h1>x<script>a*b\nc</script>y</h1>")
     );
     assert_eq!(
-        "<h1>x<style>a*b\nc</style>y</h1>\n",
+        "<h1>x<style>a*b c</style>y</h1>\n",
         round_trip("<h1>x<style>a*b\nc</style>y</h1>")
     );
-
-    // A raw text element's content is serialized as it stands, so the Markdown
-    // it holds is read as Markdown rather than as the script or stylesheet it
-    // was. Escaping it would need the escape to survive an HTML parser which
-    // does not decode references inside these elements.
-    assert_eq!(
-        "<h1>x<script>a<em>b</em>c</script>y</h1>\n",
-        round_trip("<h1>x<script>a*b*c</script>y</h1>")
-    );
-    assert_eq!(
-        "<h1>x<style>a<em>b</em>c</style>y</h1>\n",
-        round_trip("<h1>x<style>a*b*c</style>y</h1>")
-    );
-    assert_eq!(
-        "<h1>x<script><a href=\"b\">a</a></script>y</h1>\n",
-        round_trip("<h1>x<script>[a](b)</script>y</h1>")
-    );
-    // A `<` in a script is left bare, and CommonMark escapes it on the way out.
-    assert_eq!(
-        "<h1>x<script>if(a&lt;b){}</script>y</h1>\n",
-        round_trip("<h1>x<script>if(a<b){}</script>y</h1>")
-    );
-    // An `&` does survive: the reference is written back as a reference.
-    assert_eq!(
-        "<h1>x<script>a&amp;b</script>y</h1>\n",
-        round_trip("<h1>x<script>a&amp;b</script>y</h1>")
-    );
+    assert_round_trips("<h1>x<script>a*b*c</script>y</h1>");
+    assert_round_trips("<h1>x<style>a*b*c</style>y</h1>");
+    assert_round_trips("<h1>x<script>[a](b)</script>y</h1>");
 
     // `textarea` and `title` are RCDATA rather than raw text: an HTML parser
-    // does decode a character reference inside one, so nothing forces them to
-    // be serialized verbatim and they take the ordinary raw HTML inline path.
-    // That path makes the opposite trade, the one the type 6 and type 7 cases
-    // below make: the Markdown special survives, and the line ending is the
-    // half that is lost.
+    // does decode a character reference inside one, so nothing forces their
+    // structure to be serialized.
     assert_eq!(
         "<h1>x<textarea>a*b c</textarea>y</h1>\n",
         round_trip("<h1>x<textarea>a*b\nc</textarea>y</h1>")
     );
-
-    // A type 6 or type 7 element takes the mirror-image trade: its content is
-    // walked as text, so a Markdown special in it is escaped and survives...
     assert_eq!(
-        "<h1>x<div>a*b*c</div>y</h1>\n",
-        round_trip("<h1>x<div>a*b*c</div>y</h1>")
+        "<h1>x<pre>a*b c</pre>y</h1>\n",
+        round_trip("<h1>x<pre>a*b\nc</pre>y</h1>")
     );
-    // ...but that walk compresses the line ending to a space instead of
-    // escaping it, so the line ending is the half that is lost.
+
+    assert_round_trips("<h1>x<div>a*b*c</div>y</h1>");
     assert_eq!(
         "<h1>x<div>a*b c</div>y</h1>\n",
         round_trip("<h1>x<div>a*b\nc</div>y</h1>")
@@ -861,4 +838,123 @@ fn round_trip_in_an_inline_context() {
         "<h1>x<del>a*b c</del>y</h1>\n",
         round_trip("<h1>x<del>a*b\nc</del>y</h1>")
     );
+
+    // A comment goes the same way.
+    assert_eq!(
+        "<h1>x<!--a b-->y</h1>\n",
+        round_trip("<h1>x<!--a\nb-->y</h1>")
+    );
+}
+
+/// Asserts that `html` comes back as itself. pulldown-cmark ends a block with
+/// a line ending, which is the only difference these trips are allowed.
+fn assert_round_trips(html: &str) {
+    assert_eq!(
+        format!("{html}\n"),
+        round_trip(html),
+        "round trip of {html}"
+    );
+}
+
+/// Every raw HTML inline has its content walked, `<pre>`, `<script>` and
+/// `<style>` included, so each of the trips below returns the HTML it started
+/// from. `round_trip_losses_of_a_walked_raw_inline` holds the cases which do
+/// not.
+#[test]
+fn round_trip_of_a_walked_raw_inline() {
+    // A nested element.
+    assert_round_trips("<h1>x<div>a<em>b</em>c</div>y</h1>");
+    assert_round_trips("<h1>x<del>a<em>b</em>c</del>y</h1>");
+    assert_round_trips("<h1>x<pre>a<em>b</em>c</pre>y</h1>");
+
+    // A literal `<`.
+    assert_round_trips("<h1>x<div>a&lt;b&gt;c</div>y</h1>");
+    assert_round_trips("<h1>x<del>a&lt;b&gt;c</del>y</h1>");
+    assert_round_trips("<h1>x<pre>a&lt;b&gt;c</pre>y</h1>");
+    assert_round_trips("<h1>x<textarea>a&lt;b&gt;c</textarea>y</h1>");
+    // A raw text element decodes no reference, so this `<script>` holds the
+    // eleven characters `a&lt;b&gt;c` — and those are what comes back.
+    assert_round_trips("<h1>x<script>a&lt;b&gt;c</script>y</h1>");
+
+    // A literal `&`.
+    assert_round_trips("<h1>x<div>a&amp;b</div>y</h1>");
+    assert_round_trips("<h1>x<pre>a&amp;b</pre>y</h1>");
+    assert_round_trips("<h1>x<script>a&amp;b</script>y</h1>");
+
+    // Markdown specials.
+    assert_round_trips("<h1>x<div>a*b_c[d]</div>y</h1>");
+    assert_round_trips("<h1>x<pre>a*b_c[d]</pre>y</h1>");
+    assert_round_trips("<h1>x<script>a*b_c[d]</script>y</h1>");
+    assert_round_trips("<h1>x<style>a*b_c[d]</style>y</h1>");
+
+    // A `<code>` child: a code span where CommonMark allows one, and a raw
+    // HTML inline of its own inside a `<pre>`.
+    assert_round_trips("<h1>x<div>a<code>c*d</code>b</div>y</h1>");
+    assert_round_trips("<h1>x<pre>a<code>c*d</code>b</pre>y</h1>");
+    assert_round_trips("<h1><pre><code>a</code></pre></h1>");
+    assert_round_trips(r#"<h1>x<div>a<code class="q">c*d</code>b</div>y</h1>"#);
+
+    // A block context is untouched by all of this: this is an HTML block,
+    // written as it stands. `round_trip_in_a_block_context` has the rest.
+    assert_eq!("<pre>a*b\n\nc</pre>", round_trip("<pre>a*b\n\nc</pre>"));
+}
+
+/// The trips of `round_trip_of_a_walked_raw_inline` which lose something. Each
+/// assertion holds what actually comes back, and says what went missing.
+#[test]
+fn round_trip_losses_of_a_walked_raw_inline() {
+    // The `<` of a raw text element: CommonMark writes `&lt;`, and an HTML
+    // parser leaves that reference alone inside a `<script>`. This is the
+    // tradeoff the "Translating HTML nodes" section of `unsupported_html.md`
+    // takes; the alternative it names is serializing the containing block.
+    assert_eq!(
+        "<h1>x<script>if(a&lt;b){}</script>y</h1>\n",
+        round_trip("<h1>x<script>if(a<b){}</script>y</h1>")
+    );
+    assert_eq!(
+        "<h1>x<script>a&lt;em&gt;b&lt;/em&gt;c</script>y</h1>\n",
+        round_trip("<h1>x<script>a<em>b</em>c</script>y</h1>")
+    );
+
+    // `<b>` and `<i>` have no Markdown of their own, so the walk writes the
+    // `<strong>` and `<em>` their Markdown means.
+    assert_eq!(
+        "<h1><pre><strong>a</strong></pre></h1>\n",
+        round_trip("<h1><pre><b>a</b></pre></h1>")
+    );
+
+    // A `<textarea>` is RCDATA, so this one holds the characters `a<em>b`.
+    assert_eq!(
+        "<h1>x<textarea>a&lt;em&gt;b&lt;/em&gt;c</textarea>y</h1>\n",
+        round_trip("<h1>x<textarea>a<em>b</em>c</textarea>y</h1>")
+    );
+
+    // A code block ends with a line ending its content did not have.
+    assert_eq!(
+        "<pre><code>a*b\nc\n</code></pre>\n",
+        round_trip("<pre><code>a*b\nc</code></pre>")
+    );
+
+    // A line ending inside a raw HTML inline is collapsed to a space. No one
+    // encoding is decoded in every shape a raw HTML inline takes — a comment
+    // and a raw text element decode none at all — which is why the
+    // "Translating HTML nodes" section of `unsupported_html.md` collapses.
+    for (html, expected) in [
+        ("<h1>x<div>a\nb</div>y</h1>", "<h1>x<div>a b</div>y</h1>\n"),
+        ("<h1>x<pre>a\nb</pre>y</h1>", "<h1>x<pre>a b</pre>y</h1>\n"),
+        (
+            "<h1>x<script>a\nb</script>y</h1>",
+            "<h1>x<script>a b</script>y</h1>\n",
+        ),
+        (
+            "<h1>x<textarea>a\nb</textarea>y</h1>",
+            "<h1>x<textarea>a b</textarea>y</h1>\n",
+        ),
+        (
+            "<h1><pre><code>a*b\nc</code></pre></h1>",
+            "<h1><pre><code>a*b c</code></pre></h1>\n",
+        ),
+    ] {
+        assert_eq!(expected, round_trip(html), "round trip of {html}");
+    }
 }

--- a/tests/context_tests.rs
+++ b/tests/context_tests.rs
@@ -228,52 +228,69 @@ fn html_in_code_is_a_raw_inline() {
         "<pre><code>a<br>b</code></pre>",
         convert_faithful("<pre><code>a<br>b</code></pre>").unwrap()
     );
-    // An untranslatable attribute on the `<pre>` is no reason to start
-    // translating content which must stay literal.
+    // Only the tags of a raw HTML inline are HTML: a `<pre>` written as one
+    // holds CommonMark, translated like any other inline content.
     assert_eq!(
-        "# <pre><b>a</b></pre>",
+        "# <pre>**a**</pre>",
         convert_faithful("<h1><pre><b>a</b></pre></h1>").unwrap()
     );
     assert_eq!(
-        r#"# <pre class="x"><b>a</b></pre>"#,
+        r#"# <pre class="x">**a**</pre>"#,
         convert_faithful(r#"<h1><pre class="x"><b>a</b></pre></h1>"#).unwrap()
+    );
+    // A `<code>` is the exception: a code block is a CommonMark block, so in
+    // an inline context it is a raw HTML inline of its own.
+    assert_eq!(
+        r"# <pre><code>a\*b c</code></pre>",
+        convert_faithful("<h1><pre><code>a*b\nc</code></pre></h1>").unwrap()
+    );
+    // An inline `<code>` outside a `<pre>` is a code span, whose content is
+    // literal and so takes no escape.
+    assert_eq!(
+        "# <div>a`c*d`b</div>",
+        convert_faithful("<h1><div>a<code>c*d</code>b</div></h1>").unwrap()
     );
 }
 
-/// A raw text element holds literal characters rather than markup, so it is
-/// serialized whole: Markdown escaping or whitespace collapsing there would
-/// rewrite the script, style, or textarea itself.
+/// A raw text element holds literal characters rather than markup, so its
+/// structure is serialized as it stands. The Markdown specials of that text are
+/// still escaped, a CommonMark parser reading what sits between the tags of a
+/// raw HTML inline as text.
 #[test]
-fn a_raw_text_element_is_serialized_verbatim() {
+fn a_raw_text_element_escapes_the_markdown_it_holds() {
     assert_eq!(
-        "# <script>a*b_c[d]</script>",
+        r"# <script>a\*b\_c\[d\]</script>",
         convert_faithful("<h1><script>a*b_c[d]</script></h1>").unwrap()
     );
+    // The `<` escape buys nothing here: CommonMark writes `&lt;`, and an HTML
+    // parser decodes no character reference inside a raw text element. That is
+    // the tradeoff the "Translating HTML nodes" section of
+    // `unsupported_html.md` takes.
     assert_eq!(
-        "# <script>if(a<b){}</script>",
+        r"# <script>if(a\<b){}</script>",
         convert_faithful("<h1><script>if(a<b){}</script></h1>").unwrap()
     );
     assert_eq!(
-        "x<script>a*b</script>y",
+        r"x<script>a\*b</script>y",
         convert_faithful("<p>x<script>a*b</script>y</p>").unwrap()
     );
+    // An HTML block holds no CommonMark to escape, so it goes out as it
+    // stands. Without the `<body>`, html5ever files a leading `<script>` under
+    // the `<head>`, whose content is dropped.
     assert_eq!(
         "<script>a*b\nc</script>",
-        convert_faithful("<script>a*b\nc</script>").unwrap()
+        convert_faithful("<body><script>a*b\nc</script></body>").unwrap()
     );
-    // The escaped line ending survives the trip back: a CommonMark parser
-    // decodes the reference while producing the raw HTML inline. See
-    // `round_trip_in_an_inline_context` in `basic_tests.rs`.
+    // See `round_trip_in_an_inline_context` in `basic_tests.rs`.
     assert_eq!(
-        "# <script>a&#10;b</script>",
+        "# <script>a b</script>",
         convert_faithful("<h1><script>a\nb</script></h1>").unwrap()
     );
 }
 
-/// `textarea` and `title` hold no markup either, but an HTML parser decodes a
-/// character reference inside one. That decoding is the reason raw text
-/// elements must be serialized verbatim, so these two take the ordinary raw
-/// HTML inline path instead.
+/// `textarea` and `title` hold no markup either, but they are RCDATA rather
+/// than raw text, so nothing forces their structure to be serialized and they
+/// take the ordinary raw HTML inline path instead.
 #[test]
 fn an_rcdata_element_is_translated() {
     assert_eq!(
@@ -284,8 +301,6 @@ fn an_rcdata_element_is_translated() {
         r"# <title>a\*b\*c</title>",
         convert_faithful("<h1><title>a*b*c</title></h1>").unwrap()
     );
-    // The walk compresses a line ending to a space rather than escaping it, so
-    // that is the half this path loses.
     assert_eq!(
         "# <textarea>a b</textarea>",
         convert_faithful("<h1><textarea>a\nb</textarea></h1>").unwrap()
@@ -296,24 +311,57 @@ fn an_rcdata_element_is_translated() {
     );
 }
 
-/// A line ending in a raw HTML inline ends the leaf block holding it: a blank
-/// line ends a paragraph, and a single line ending ends an ATX heading or a
-/// table row. Each is therefore written as a character reference.
+/// "All raw HTML inlines will have whitespace collapsed in their contents
+/// (including newlines, which would otherwise be problematic)" — the
+/// "Translating HTML nodes" section of `unsupported_html.md`. Encoding the line
+/// ending instead would need a parser which decodes a character reference
+/// there, and neither a comment nor a raw text element has one.
 #[test]
-fn a_raw_inline_escapes_its_line_endings() {
+fn a_raw_inline_collapses_the_whitespace_of_its_content() {
+    // Type 6.
+    assert_eq!(
+        "# x<div>a b</div>y",
+        convert_faithful("<h1>x<div>a\nb</div>y</h1>").unwrap()
+    );
+    // Type 7.
+    assert_eq!(
+        "a<del> b </del>c",
+        convert_faithful("<p>a<del>\n  b\n</del>c</p>").unwrap()
+    );
+    // Type 1, whose whitespace carries the meaning of the element — the loss
+    // this collapse takes on.
+    assert_eq!(
+        "# <pre>a b</pre>",
+        convert_faithful("<h1><pre>a\n  b</pre></h1>").unwrap()
+    );
+    // Ordinary flow content collapses the same way.
+    assert_eq!("a b", convert_faithful("<p>a\nb</p>").unwrap());
+    assert_eq!("# a b", convert_faithful("<h1>a\n  b</h1>").unwrap());
+}
+
+/// That collapse is scoped to the contents; an attribute value keeps its
+/// whitespace. A bare line ending there would end the leaf block holding the
+/// element, so that alone is encoded — the open tag passes through CommonMark
+/// verbatim, and the HTML parser reading the result decodes it back.
+#[test]
+fn a_raw_inline_escapes_the_line_endings_of_its_attributes() {
     assert_eq!(
         r#"a<em foo="1&#10;&#10;2">y</em>b"#,
         convert_faithful("<p>a<em foo=\"1\n\n2\">y</em>b</p>").unwrap()
     );
+    // Whitespace which is not a line ending is left alone.
     assert_eq!(
-        "# <pre>x&#10;y</pre>",
-        convert_faithful("<h1><pre>x\ny</pre></h1>").unwrap()
+        r#"# a<div title="x  y">z w</div>b"#,
+        convert_faithful("<h1>a<div title=\"x  y\">z  w</div>b</h1>").unwrap()
     );
-    // The parser folds a literal CRLF into a line feed, so the carriage return
-    // has to arrive as a character reference to survive.
+    // A raw HTML inline nested in another one keeps its attribute value too.
     assert_eq!(
-        "# <pre>x&#13;&#10;y</pre>",
-        convert_faithful("<h1><pre>x&#13;&#10;y</pre></h1>").unwrap()
+        r#"# a<div title="p  q"><em foo="r  s">t</em></div>b"#,
+        convert_faithful(r#"<h1>a<div title="p  q"><em foo="r  s">t</em></div>b</h1>"#).unwrap()
+    );
+    assert_eq!(
+        r#"# a<div title="p&#10;q"><em foo="r&#10;s">t</em></div>b"#,
+        convert_faithful("<h1>a<div title=\"p\nq\"><em foo=\"r\ns\">t</em></div>b</h1>").unwrap()
     );
     assert_eq!(
         concat!(
@@ -327,8 +375,8 @@ fn a_raw_inline_escapes_its_line_endings() {
         )
         .unwrap()
     );
-    // Only a blank line ends a type 6 HTML block, so one keeps the rest of its
-    // line structure.
+    // An HTML *block* keeps its line structure: only a blank line ends a type 6
+    // one, so only that is encoded.
     assert_eq!(
         "<div>a\n&#10;b</div>",
         convert_faithful("<div>a\n\nb</div>").unwrap()
@@ -340,13 +388,15 @@ fn a_raw_inline_escapes_its_line_endings() {
 /// or preformatted text itself.
 #[test]
 fn a_type_1_block_keeps_its_blank_lines() {
+    // Without the `<body>`, html5ever files a leading `<script>` or `<style>`
+    // under the `<head>`, whose content is dropped.
     assert_eq!(
         "<script>a\n\nb</script>",
-        convert_faithful("<script>a\n\nb</script>").unwrap()
+        convert_faithful("<body><script>a\n\nb</script></body>").unwrap()
     );
     assert_eq!(
         "<style>a\n\nb</style>",
-        convert_faithful("<style>a\n\nb</style>").unwrap()
+        convert_faithful("<body><style>a\n\nb</style></body>").unwrap()
     );
     assert_eq!(
         "<pre>a\n\nb</pre>",
@@ -356,8 +406,10 @@ fn a_type_1_block_keeps_its_blank_lines() {
         "<textarea>a\n\nb</textarea>",
         convert_faithful("<textarea>a\n\nb</textarea>").unwrap()
     );
+    // In an inline context the same element is a raw HTML inline, whose blank
+    // lines are collapsed with the rest of its whitespace.
     assert_eq!(
-        "# <script>a&#10;&#10;b</script>",
+        "# <script>a b</script>",
         convert_faithful("<h1><script>a\n\nb</script></h1>").unwrap()
     );
 }
@@ -410,7 +462,10 @@ fn a_title_escapes_its_line_endings() {
     );
 }
 
-/// A comment is a type 2 HTML block, which likewise ends at its own `-->`.
+/// A comment is a type 2 HTML block, which likewise ends at its own `-->`. In
+/// an inline context it is a raw HTML inline instead, whose whitespace is
+/// collapsed: no parser decodes a character reference inside a comment, so
+/// encoding the line ending would be no use.
 #[test]
 fn a_comment_follows_its_context() {
     assert_eq!("<!--a\n\nb-->", convert_faithful("<!--a\n\nb-->").unwrap());
@@ -423,12 +478,72 @@ fn a_comment_follows_its_context() {
         convert_faithful("<blockquote><!--c--></blockquote>").unwrap()
     );
     assert_eq!(
-        "# x<!--a&#10;b-->y",
+        "# x<!--a b-->y",
         convert_faithful("<h1>x<!--a\nb-->y</h1>").unwrap()
     );
     assert_eq!(
-        "x<!--a&#10;&#10;b-->y",
+        "x<!--a b-->y",
         convert_faithful("<p>x<!--a\n\nb-->y</p>").unwrap()
+    );
+    assert_eq!(
+        "# x<!--a b-->y",
+        convert_faithful("<h1>x<!--a\r\nb-->y</h1>").unwrap()
+    );
+    // A comment inside a raw HTML inline is a comment still.
+    assert_eq!(
+        "# <div>x<!--a b-->y</div>",
+        convert_faithful("<h1><div>x<!--a\nb-->y</div></h1>").unwrap()
+    );
+}
+
+/// The html5ever tokenizer hands a CDATA section and a processing instruction
+/// back as comments, so both take the type 2 path above rather than the type 5
+/// and type 3 ones they were written as.
+#[test]
+fn a_cdata_section_and_a_processing_instruction_are_comments() {
+    assert_eq!(
+        "<!--[CDATA[x\n\ny]]-->",
+        convert_faithful("<![CDATA[x\n\ny]]>").unwrap()
+    );
+    assert_eq!(
+        "a<!--[CDATA[x y]]-->b",
+        convert_faithful("<p>a<![CDATA[x\ny]]>b</p>").unwrap()
+    );
+    assert_eq!(
+        "a<!--?php echo \"x y\"; ?-->b",
+        convert_faithful("<p>a<?php echo \"x\ny\"; ?>b</p>").unwrap()
+    );
+}
+
+/// What a raw HTML inline holds is an inline context as well, so the rule of
+/// `a_commonmark_block_in_an_inline_context_is_a_raw_inline` holds one element
+/// deeper.
+#[test]
+fn a_commonmark_block_inside_a_raw_inline_is_a_raw_inline() {
+    assert_eq!(
+        "# <div><blockquote>a</blockquote></div>",
+        convert_faithful("<h1><div><blockquote>a</blockquote></div></h1>").unwrap()
+    );
+    assert_eq!(
+        "# <div><ul><li>a</li></ul></div>",
+        convert_faithful("<h1><div><ul><li>a</li></ul></div></h1>").unwrap()
+    );
+    assert_eq!(
+        "# <div><h2>a</h2></div>",
+        convert_faithful("<h1><div><h2>a</h2></div></h1>").unwrap()
+    );
+    assert_eq!(
+        "# <div><hr></div>",
+        convert_faithful("<h1><div><hr></div></h1>").unwrap()
+    );
+    // What CommonMark can write inline is still translated there.
+    assert_eq!(
+        "# <div>a*b*c</div>",
+        convert_faithful("<h1><div>a<em>b</em>c</div></h1>").unwrap()
+    );
+    assert_eq!(
+        r"# <div>a[l\*m](u)b</div>",
+        convert_faithful(r#"<h1><div>a<a href="u">l*m</a>b</div></h1>"#).unwrap()
     );
 }
 


### PR DESCRIPTION
Only the tags of a raw HTML inline are HTML; what sits between them is CommonMark text. Three kinds of element did not follow that rule:

- `<script>` and `<style>` were serialized whole, so the Markdown in them went out unescaped and `a*b*c` in a script came back as `a<em>b</em>c`.
- A `<pre>` in an inline context took the same verbatim path, and its `<code>` child then tried to write a code block where only inline content may appear.
- A comment, and every raw HTML inline, had its line endings written as `&#10;`. That encoding only works where the HTML parser decodes character references, and it decodes none inside a comment or a raw text element, so those five characters came back as themselves.

`Handlers::walk_raw_html_inline_children` now walks the children of a serialized element as inline CommonMark, whatever the element's own tag, and the "Translating HTML nodes" section of `unsupported_html.md` collapses the whitespace of the result — the one treatment which needs no parser to decode anything. `RAW_TEXT_ELEMENTS`, `serialize_inline_verbatim` and `escape_inline_line_endings` go with the old path.

The collapse is scoped to the contents, so an attribute value keeps its whitespace; a bare line ending there would still end the leaf block holding the element, so `escape_attribute_line_endings` encodes the open tag alone.

`Context::is_inline` names the test the macros and handlers were all spelling out, and `is_pre_content` keeps a `<pre>` or `<code>` which is being written as HTML from claiming its content is literal text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved whitespace handling in preformatted content, inline comments, and raw HTML.
  - Preserved expected behavior for code blocks and raw HTML in inline contexts.
  - Corrected handling of line endings, blank lines, attributes, and nested content during round trips.

- **Tests**
  - Added coverage for raw HTML, comments, code and preformatted elements, CDATA, processing instructions, and whitespace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->