### PR TITLE
Fix: drop the link references of a walk which is thrown away.

### DIFF
--- a/src/element_handler/anchor.rs
+++ b/src/element_handler/anchor.rs
@@ -25,7 +25,8 @@ use crate::{
 ///   reference-style links.
 /// - **Speculative conversion:** If a container handler (such as a table) converts children speculatively
 ///   and then discards the result in faithful mode, any reference-style links inside those children
-///   will remain in the buffer for document-level append unless handled.
+///   will remain in the buffer for document-level append unless handled. A handler which discards a
+///   walk it has already made takes a [`LinkReferenceCheckpoint`] first.
 pub(super) struct AnchorElementHandler {}
 
 impl AnchorElementHandler {
@@ -35,6 +36,22 @@ impl AnchorElementHandler {
 
     pub(super) fn new() -> Self {
         Self {}
+    }
+}
+
+/// The state of the link reference buffer before a speculative walk. A handler
+/// which then writes itself as HTML rolls back, so the document does not end
+/// with definitions nothing refers to.
+pub(crate) struct LinkReferenceCheckpoint(usize);
+
+impl LinkReferenceCheckpoint {
+    pub(crate) fn new() -> Self {
+        Self(AnchorElementHandler::LINK_REFERENCES.with(|links| links.borrow().len()))
+    }
+
+    /// Drops every definition buffered since [`Self::new`].
+    pub(crate) fn roll_back(self) {
+        AnchorElementHandler::LINK_REFERENCES.with(|links| links.borrow_mut().truncate(self.0));
     }
 }
 

--- a/src/element_handler/element_util.rs
+++ b/src/element_handler/element_util.rs
@@ -244,6 +244,30 @@ macro_rules! serialize_element_when_faithful {
 
 pub(crate) use serialize_element_when_faithful;
 
+/// [`serialize_element_when_faithful!`] for a handler which has already walked
+/// its children. Writing the element as HTML throws that walk away, so the link
+/// reference definitions it buffered are rolled back to `checkpoint` first. See
+/// [`anchor::LinkReferenceCheckpoint`].
+///
+/// [`anchor::LinkReferenceCheckpoint`]:
+///     crate::element_handler::anchor::LinkReferenceCheckpoint
+macro_rules! serialize_walked_element_when_faithful {
+    ($handlers:expr, $element:expr, $condition:expr, $checkpoint:expr) => {
+        if $handlers.options().translation_mode == $crate::options::TranslationMode::Faithful
+            && $condition
+        {
+            $checkpoint.roll_back();
+            return Some(
+                $crate::element_handler::element_util::serialize_element_result(
+                    $handlers, &$element,
+                ),
+            );
+        }
+    };
+}
+
+pub(crate) use serialize_walked_element_when_faithful;
+
 /// Returns from the enclosing handler with `element` written as HTML when it
 /// carries more attributes than its Markdown translation can express.
 /// `num_attrs_allowed` of -1 rejects every attribute set, serializing the

--- a/src/element_handler/pre.rs
+++ b/src/element_handler/pre.rs
@@ -2,9 +2,10 @@ use crate::{
     Element,
     element_handler::{
         HandlerResult, Handlers,
+        anchor::LinkReferenceCheckpoint,
         element_util::{
-            serialize_element, serialize_element_result, serialize_if_extra_attrs_or_inline,
-            serialize_when_faithful,
+            serialize_element_result, serialize_if_extra_attrs_or_inline,
+            serialize_walked_element_when_faithful,
         },
     },
     node_util::get_node_tag_name,
@@ -34,12 +35,16 @@ pub(super) fn pre_handler(handlers: &dyn Handlers, element: Element) -> Option<H
     };
 
     if handlers.options().translation_mode == TranslationMode::Pure || is_simple_code_block {
+        // The walk is speculative: a child which only HTML can express sends
+        // the whole `<pre>` out as HTML, discarding this content.
+        let checkpoint = LinkReferenceCheckpoint::new();
         let result = handlers.walk_children(element.node, element.context);
 
-        serialize_when_faithful!(
+        serialize_walked_element_when_faithful!(
             handlers,
+            element,
             !result.markdown_translated,
-            serialize_element(handlers, &element)
+            checkpoint
         );
 
         Some(frame_as_block(&result.content).into())

--- a/src/element_handler/table.rs
+++ b/src/element_handler/table.rs
@@ -1,6 +1,7 @@
 use crate::Context;
-use crate::element_handler::element_util::serialize_element_result;
+use crate::element_handler::anchor::LinkReferenceCheckpoint;
 use crate::element_handler::element_util::serialize_if_extra_attrs_or_inline;
+use crate::element_handler::element_util::serialize_walked_element_when_faithful;
 use crate::element_handler::{Element, HandlerResult, Handlers};
 use crate::node_util::{get_node_tag_name, get_parent_node};
 use crate::options::TranslationMode;
@@ -26,6 +27,9 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         return handlers.fallback(element);
     }
 
+    // The extraction walks every caption, header and cell, and a child which
+    // only HTML can express throws that walk away.
+    let checkpoint = LinkReferenceCheckpoint::new();
     let ExtractedTable {
         captions,
         mut headers,
@@ -33,12 +37,17 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
         all_children_translated,
     } = extract_table_content(handlers, element.node);
 
-    if handlers.options().translation_mode == TranslationMode::Faithful && !all_children_translated
-    {
-        return Some(serialize_element_result(handlers, &element));
-    }
+    serialize_walked_element_when_faithful!(
+        handlers,
+        element,
+        !all_children_translated,
+        checkpoint
+    );
 
     if rows.is_empty() && headers.is_empty() {
+        // The walk below covers the same children, so without this every link
+        // reference would reach the end of the document twice.
+        checkpoint.roll_back();
         let content = handlers.walk_children_content(element.node, element.context);
         let content = content.trim_matches('\n');
         if content.is_empty() {
@@ -55,9 +64,7 @@ pub(crate) fn table_handler(handlers: &dyn Handlers, element: Element) -> Option
     // headerless form: the delimiter row which makes the block a table has to
     // follow a header row. Faithful mode writes HTML rather than invent one;
     // pure mode has no such fallback and writes an empty header row.
-    if handlers.options().translation_mode == TranslationMode::Faithful && headers.is_empty() {
-        return Some(serialize_element_result(handlers, &element));
-    }
+    serialize_walked_element_when_faithful!(handlers, element, headers.is_empty(), checkpoint);
     if headers.is_empty() {
         headers = vec![String::new(); num_columns];
     }

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -102,3 +102,32 @@ fn a_link_destination_escapes_its_line_endings() {
         convert_faithful(r#"<p><a href="u(v)">t</a></p>"#).unwrap()
     );
 }
+
+/// Faithful mode writing every link as a reference-style one, which is what
+/// puts a definition in the buffer the rollback empties.
+fn referenced_link_converter() -> HtmlToMarkdown {
+    HtmlToMarkdown::builder()
+        .options(Options {
+            translation_mode: TranslationMode::Faithful,
+            link_style: LinkStyle::Referenced,
+            ..Default::default()
+        })
+        .build()
+}
+
+/// The same rollback for the other two handlers which may throw a walk away.
+#[test]
+fn a_serialized_container_drops_the_link_references_it_walked() {
+    let converter = referenced_link_converter();
+
+    // A `<caption>` has no CommonMark spelling, so the whole table serializes.
+    let table = concat!(
+        r#"<table><caption>c</caption><tbody><tr><td><a href="q">z</a></td></tr>"#,
+        "</tbody></table>"
+    );
+    assert_eq!(table, converter.convert(table).unwrap());
+
+    // A `<pre>` holding more than a single `<code>` serializes as well.
+    let pre = r#"<pre>a<div><a href="q">z</a></div></pre>"#;
+    assert_eq!(pre, converter.convert(pre).unwrap());
+}


### PR DESCRIPTION
`AnchorElementHandler` buffers a reference-style link's definition in a thread-local for the document-level append. A container which walks its children speculatively and then writes itself as HTML throws that walk away, but the definitions stayed in the buffer: the document ended with definitions nothing referred to, and every later link was numbered as though the discarded ones counted.

`LinkReferenceCheckpoint` records the buffer's length before such a walk and truncates back to it, and the new
`serialize_walked_element_when_faithful!` pairs the rollback with the serialization so the two cannot come apart. `table_handler` and `pre_handler` are the two handlers which walk before deciding; the table also rolls back before re-walking the same children for a caption-only table, which was appending every definition twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original HTML for certain tables and preformatted blocks when faithful conversion cannot produce Markdown.
  * Prevented duplicate or unintended link-reference definitions during conversion.
* **Tests**
  * Added coverage for link references encountered while processing serialized containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->